### PR TITLE
Add Dan as a lead for the Serving API Working Group

### DIFF
--- a/WORKING-GROUPS.md
+++ b/WORKING-GROUPS.md
@@ -63,6 +63,7 @@ API
 | &nbsp;                                                   | Leads      | Company | Profile                                 |
 | -------------------------------------------------------- | ---------- | ------- | --------------------------------------- |
 | <img width="30px" src="https://github.com/mattmoor.png"> | Matt Moore | Google  | [mattmoor](https://github.com/mattmoor) |
+| <img width="30px" src="https://github.com/dgerd.png"> | Dan Gerdesmeier | Google  | [dgerd](https://github.com/dgerd) |
 
 ## Build
 


### PR DESCRIPTION
Going over the requirements from [here](https://github.com/knative/community/blob/master/ROLES.md#lead)

> Recognized as having expertise in the group’s subject matter.

Dan has been deeply involved in the API Working Group for some time now.
Dan was a key voice in the "v1beta1 task force", as well as a number of the
discussions leading up to its formation.  Dan has been driving our
conformance efforts in serving around both the control plane and runtime
contract.

> Approver for some part of the codebase for at least 3 months.

Dan was added as an approver on 2/14.  I can wait until tomorrow to remove the hold. 😈 

> Member for at least 1 year or 50% of project lifetime, whichever is shorter.

Dan joined in September (9 months ago), which is 50% of the project lifetime.

> Primary reviewer for 20 substantial PRs.

The v1beta1 work alone was a dozen or so PRs.  He's reviewed many more as the primary reviewer :)

> Reviewed or merged at least 50 PRs.

I see 30 closed PRs authored, and 84 more with him assigned.

> Sponsored by the technical oversight committee.

/assign @vaikas-google @evankanderson 



/hold
/assign @dgerd 