### PR TITLE
Add Donna Malayeri to fill Google's open steering committee seat.

### DIFF
--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -86,7 +86,7 @@ first name):
 | &nbsp;                                                    | Member           | Organization | Profile                                    |
 | --------------------------------------------------------- | ---------------- | ------------ | ------------------------------------------ |
 | <img width="30px" src="https://github.com/bsnchan.png">   | Brenda Chan      | Pivotal      | [@bsnchan](https://github.com/bsnchan)     |
-| <img width="30px" src="https://github.com/dewitt.png">    | DeWitt Clinton   | Google       | [@dewitt](https://github.com/dewitt)       |
+| <img width="30px" src="https://github.com/lindydonna.png">    | Donna Malayeri   | Google       | [@lindydonna](https://github.com/lindydonna)       |
 | <img width="30px" src="https://github.com/mchmarny.png">  | Mark Chmarny     | Google       | [@mchmarny](https://github.com/mchmarny)   |
 | <img width="30px" src="https://github.com/mbehrendt.png"> | Michael Behrendt | IBM          | [@mbehrendt](https://github.com/mbehrendt) |
 | <img width="30px" src="https://github.com/pmorie.png">    | Paul Morie       | Red Hat      | [@pmorie](https://github.com/pmorie)       |


### PR DESCRIPTION
As many know, I'm switching teams at Google and will be handing off Knative-related responsibilities shortly. Donna Malayeri is the replacement for the vacant steering committee seat. Welcome, Donna!