### PR TITLE
Add markusthoemmes as Scaling Working Group Lead.

### DIFF
--- a/WORKING-GROUPS.md
+++ b/WORKING-GROUPS.md
@@ -209,6 +209,7 @@ Autoscaling
 | &nbsp;                                                        | Leads          | Company | Profile                                           |
 | ------------------------------------------------------------- | -------------- | ------- | ------------------------------------------------- |
 | <img width="30px" src="https://github.com/josephburnett.png"> | Joseph Burnett | Google  | [josephburnett](https://github.com/josephburnett) |
+| <img width="30px" src="https://github.com/markusthoemmes.png"> | Markus Thömmes | Red Hat  | [markusthoemmes](https://github.com/markusthoemmes) |
 
 ## Productivity
 


### PR DESCRIPTION
I propose to add Markus Thömmes (Red Hat) as an additional Scaling Working Group Lead.

Requirements: ([link](https://github.com/knative/community/blob/6fe7db2a5f984bf8a9c7855f12073cb3ef3df6e9/ROLES.md#lead)):
> Working group leads, or just ‘leads’, are approvers of an entire area that have demonstrated good judgement and responsibility. Leads accept design proposals and approve design decisions for their area of ownership.
> 
> Getting to be a lead of an existing working group:
> - Recognized as having expertise in the group’s subject matter.
> - Approver for some part of the codebase for at least 3 months.
> - Member for at least 1 year or 50% of project lifetime, whichever is shorter.
> - Primary reviewer for 20 substantial PRs.
> - Reviewed or merged at least 50 PRs.
> - Sponsored by the technical oversight committee.
> 
> Additional requirements for leads of a new working group:
> - Originally authored or contributed major functionality to the group's area.
> - An approver in the OWNERS file for the group’s code.

Markus has expertise in the Scaling WG subject matter.  He has worked deeply with the core autoscaling algorithm to stabilize and improve it ([#1091](https://github.com/knative/serving/pull/1091), [#1194](https://github.com/knative/serving/pull/1194), [#3289](https://github.com/knative/serving/pull/3289)).  Additionally he was a core contributor to Open Whisk and has prior expertise in the autoscaling problem space ([Open Whisk commits](https://github.com/apache/incubator-openwhisk/commits?author=markusthoemmes)).

He has been an approver in the Scaling WG for over 6 months ([Nov. 7, 2018](https://github.com/knative/serving/pull/2425)).  He has been an active code contributor and reviewer.  Additionally he has contributed directly to the working group's roadmap ([2019 roadmap]()).

Markus has contributed a lot of critical relayering to the autoscaling code base.  E.g. moving activation to the Autoscaler from the Activator ([#2198](https://github.com/knative/serving/pull/2198), [#2215](https://github.com/knative/serving/pull/2215), [#1923](https://github.com/knative/serving/pull/1923)) and now separating autoscaler metrics from the decider to allow for HPA scale-to-zero and HPA custom metrics ([#4236](https://github.com/knative/serving/pull/4236), [#4007](https://github.com/knative/serving/pull/4007), [#4260](https://github.com/knative/serving/pull/4260), [#4237](https://github.com/knative/serving/pull/4237)).  As such, he has a good view and vision for the full autoscaling system.

Markus has demonstrated the good judgement and responsibility necessary to serve as Scaling Working Group Lead over a sustained period of time.