### PR TITLE
Fix broken relative links to pre-move content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ following steps:
 
 - Submit PRs to knative/serving with user documentation for your feature,
   including usage examples when possible. Add documentation to the `serving`
-  folder of [knative/docs](../serving).
+  folder of [knative/docs](https://github.com/knative/docs/tree/master/docs/serving).
 
 _Note that we prefer bite-sized PRs instead of giant monster PRs. It's therefore
 preferable if you can introduce large features in small, individually-reviewable

--- a/DOCS-CONTRIBUTING.md
+++ b/DOCS-CONTRIBUTING.md
@@ -88,8 +88,8 @@ There are a couple different ways to jump in to the Knative doc set:
   in the backlog.
 
 - Try out Knative and send us feedback. For example, run through one of the
-  [install guides](../install/README.md) and then try
-  [Getting Started with Knative Serving](../install/getting-started-knative-app.md).
+  [install guides](https://knative.dev/docs/install/) and then try
+  [Getting Started with Knative Serving](https://knative.dev/docs/install/getting-started-knative-app/).
 
   You should keep a
   [friction log](https://devrel.net/developer-experience/an-introduction-to-friction-logging)
@@ -352,7 +352,7 @@ Knative Steering committee to ask that you be added as a member of the Knative
 org.
 
 Once your sponsor notifies you that you've been added to the Knative org, open a
-PR to add yourself as a docs-reviewer in the [OWNERS_ALIASES](../OWNERS_ALIASES)
+PR to add yourself as a docs-reviewer in the [OWNERS_ALIASES](./OWNERS_ALIASES)
 file.
 
 ## Approver
@@ -408,4 +408,4 @@ to become an approver at a meeting of the Documentation Working Group.
 Once you feel you meet the criteria, you can ask one of the current approvers to
 nominate you to become an approver. If all existing approvers agree that you
 meet the criteria open a PR to add yourself as a docs-approver in the
-[OWNERS_ALIASES](../OWNERS_ALIASES) file.
+[OWNERS_ALIASES](./OWNERS_ALIASES) file.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Other Documents
 ## Introduction
 
 Knative is a Kubernetes-based platform to build, deploy, and manage modern
-serverless workloads. See [Knative docs](../docs/README.md) for in-depth
+serverless workloads. See [Knative docs](https://knative.dev/docs) for in-depth
 information about using Knative.
 
 ## Knative authors
@@ -59,7 +59,7 @@ tools, platforms, languages, and products. By submitting a tutorial you can
 share your experience and help others who are solving similar problems.
 
 Community tutorials are stored in Markdown files under the `community` folder
-[Community Samples](../community/samples/README.md). These documents are
+[Community Samples](https://knative.dev/docs/samples/). These documents are
 contributed, reviewed, and maintained by the community.
 
 Submit a Pull Request to the community sample directory under the Knative

--- a/WORKING-GROUPS.md
+++ b/WORKING-GROUPS.md
@@ -105,7 +105,7 @@ conventions
 
 ## Documentation
 
-Knative documentation, especially the [Docs](../docs/README.md) repo.
+Knative documentation, especially the [Docs](https://knative.dev/docs) repo.
 
 | Artifact                   | Link                                                                                                                                                                                                    |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Fixing up the broken links between content here and content in the /docs/ repo since we moved to the new repo.

Fixes #3 