### PR TITLE
Add vagababov as scaling working group lead

### DIFF
--- a/WORKING-GROUPS.md
+++ b/WORKING-GROUPS.md
@@ -210,8 +210,8 @@ Autoscaling
 
 | &nbsp;                                                        | Leads          | Company | Profile                                           |
 | ------------------------------------------------------------- | -------------- | ------- | ------------------------------------------------- |
-| <img width="30px" src="https://github.com/josephburnett.png"> | Joseph Burnett | Google  | [josephburnett](https://github.com/josephburnett) |
 | <img width="30px" src="https://github.com/markusthoemmes.png"> | Markus Thömmes | Red Hat  | [markusthoemmes](https://github.com/markusthoemmes) |
+| <img width="30px" src="https://github.com/vagababov.png"> | Victor Agababov | Google  | [vagababov](https://github.com/vagababov) |
 
 ## Productivity
 


### PR DESCRIPTION
I propose to replace me (josephburnett) with Victor (vagababov) as Scaling Working Group lead.  He has been very active as a contributor and leader in the scaling space.

[Requirements](https://github.com/knative/community/blob/e63f566120fe45ffdec92caf061ecf66a3c933aa/ROLES.md#lead):

[X] Recognized as having expertise in the group’s subject matter.
   - Design and Implementation of the Revision based activation
   - Design and implementation of the burst capacity handling
   - Numerous stability and reliability improvements across the autoscaling stack, etc...

[X] Approver for some part of the codebase for at least 3 months (approver for part of the codebase since Mar 19 (4mo+)

[X] Member for at least 1 year or 50% of project lifetime, whichever is shorter (joined in late November, 2018 - 8mo+. Project just celebrated 1y, so 8mo > 6mo (50%))

[X] Primary reviewer for 20 substantial PRs (68 large,  17 XL, 8 XXL)

[X] Reviewed or merged at least 50 PRs (In addition to reviewed stats above 97 commits in the area)

[ ] Sponsored by the technical oversight committee.