### PR TITLE
Make clear that you cannot commit from `noreply`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,12 @@ necessary because you own the copyright to your changes, even after your
 contribution becomes part of this project. So this agreement simply gives us
 permission to use and redistribute your contributions as part of the project.
 
+Note: Your contributions are verified using the email address for which you
+use to sign the CLA. Therefore, 
+[setting your GitHub account to private](https://help.github.com/en/articles/setting-your-commit-email-address)
+is unsupported because all commits from private accounts are sent from the `noreply` 
+email address.
+
 ## Design documents
 
 Any substantial design deserves a design document. Design documents are written

--- a/DOCS-CONTRIBUTING.md
+++ b/DOCS-CONTRIBUTING.md
@@ -35,6 +35,12 @@ necessary because you own the copyright to your changes, even after your
 contribution becomes part of this project. So this agreement simply gives us
 permission to use and redistribute your contributions as part of the project.
 
+Note: Your contributions are verified using the email address for which you
+use to sign the CLA. Therefore, 
+[setting your GitHub account to private](https://help.github.com/en/articles/setting-your-commit-email-address)
+is unsupported because all commits from private accounts are sent from the `noreply` 
+email address.
+
 ### Style guide
 
 Knative documentation follows the


### PR DESCRIPTION
Because contributions are tracked by the email address used to sign CLAs, add statement making it clear that your GitHub account will send commits using `noreply` as the email address if you set you account to private.