### PR TITLE
Format footnotes to be more obviously footnotes.

### DIFF
--- a/mechanics/FEATURE-TRACKS.md
+++ b/mechanics/FEATURE-TRACKS.md
@@ -38,14 +38,14 @@ leads for all involved working groups should be involved throughout the process.
 
 ## Step 2: The Proposal
 
-All non-trivial[2.1] features deserve a design for 
+All non-trivial<sup>[2.1](#2.1)</sup> features deserve a design for 
 articulating the solution to their problem statement. This should be done in a 
 **Google doc**
-([template](https://docs.google.com/document/d/1s6IIU98bi5FlRNmmBaLAn1rgoleK_ovcL746L7NHq0c/edit)) 
+([template](https://docs.google.com/document/d/1s6IIU98bi5FlRNmmBaLAn1rgoleK_ovcL746L7NHq0c/edit) -- make a copy!) 
 under the appropriate folder in the [Team 
-Drive](https://drive.google.com/corp/drive/u/0/folders/0APnJ_hRs30R2Uk9PVA)[2.2].
+Drive](https://drive.google.com/corp/drive/u/0/folders/0APnJ_hRs30R2Uk9PVA)<sup>[2.2](#2.2)</sup>.
 If the solution is clear and non-contentious, then the doc may be very short!
-For major[2.3] designs, once the proposal is accepted it should be converted to
+For major<sup>[2.3](#2.3)</sup> designs, once the proposal is accepted it should be converted to
 markdown and committed to the appropriate GitHub repo.
 
 However, the bigger the feature the less likely this is to be true.  Designs 
@@ -58,17 +58,17 @@ The design should summarize the problem statement but the core focus should be
 on the end state (the **"what"**); think about how we might document the feature 
 in the end state and give us a preview of what that might look like.  For some 
 features there is complexity in getting from where we are to that end state.  
-Such features will also need a detailed migration plan (the **"how"**[2.4]).
+Such features will also need a detailed migration plan (the **"how"**<sup>[2.4](#2.4)</sup>).
 Designs should also list reviewers that they expect to sign-off (the **"who"**),
 this should be the WG leads (or their delegate).
 
-> [2.1] - For the moment, this is at the discretion of the Working Group Lead.
+> <a name="2.1"><sup>2.1</sup></a> - For the moment, this is at the discretion of the Working Group Lead.
 
-> [2.2] - For read/write access join the [knative-dev](https://groups.google.com/forum/#!forum/knative-dev) Google group.
+> <a name="2.2"><sup>2.2</sup></a> - For read/write access join the [knative-dev](https://groups.google.com/forum/#!forum/knative-dev) Google group.
 
-> [2.3] - This is at the discretion of WG leads, since doing this for every change will quickly flood the repo and make things _less_ discoverable.
+> <a name="2.3"><sup>2.3</sup></a> - This is at the discretion of WG leads, since doing this for every change will quickly flood the repo and make things _less_ discoverable.
 
-> [2.4] - For a detailed outline of how to stage component changes, please [read this](https://github.com/knative/serving/issues/2639).
+> <a name="2.4"><sup>2.4</sup></a> - For a detailed outline of how to stage component changes, please [read this](https://github.com/knative/serving/issues/2639).
 
 ## Step 3: The Review
 
@@ -88,7 +88,7 @@ review may not be an immediate decision, and the contributor may get sent back
 to gather more information and iterate.
 
 When a proposal is accepted, the leads should designate one or more 
-reviewers[3.1] within the WG as "sponsors" for the 
+reviewers<sup>[3.1](#3.1)</sup> within the WG as "sponsors" for the 
 feature to help shepherd it through the process.  It is recommended that at 
 least one sponsor be an approver 
 ([e.g.](https://github.com/knative/serving/blob/2018fcd98c18922cb1ce8b0207aa9aa6bef5eed1/OWNERS_ALIASES#L19)), 
@@ -97,19 +97,19 @@ but if non-approvers
 are listed, they should be considered the primary reviewer(s) so that they can 
 hone their review skills and work towards approver.
 
-> [3.1] - Leads should try to be sensitive to the relative timezone of contributors with their sponsors to reduce cycle times on reviews.
+> <a name="^3.1"><sup>3.1</sup></a> - Leads should try to be sensitive to the relative timezone of contributors with their sponsors to reduce cycle times on reviews.
 
 ## Step 4: The Breakdown
 
 At a minimum, large features should be broken down into reasonably sized Pull 
 Requests.  However, large features (e.g. multi-milestone) may need to be broken 
 down into a number of smaller issues (no bigger than a milestone).  For these 
-large features, the design document should eventually[4.1] include, and the
+large features, the design document should eventually<sup>[4.1](#4.1)</sup> include, and the
 broad strokes of how the work will be broken down. For these very large features,
 the sponsor would then help set up a Github project containing issues for all of
 the pertinent items.  Until all of this completes, the feature is not done.
 
-> [4.1] - WG Leads can decide how much of the work breakdown to front-load, but what is important is that all parties (feature owner, lead, and sponsors) understand the full-scope of the work to be done.
+> <a name="4.1"><sup>4.1</sup></a> - WG Leads can decide how much of the work breakdown to front-load, but what is important is that all parties (feature owner, lead, and sponsors) understand the full-scope of the work to be done.
 
 
 ## Step 5: The Planning Process


### PR DESCRIPTION
I was reading the feature tracks document and thought that we'd accidentally left in a bunch of links, rather than that we were trying to do footnotes. Per [stackoverflow suggestion](https://stackoverflow.com/questions/25579868/how-to-add-footnotes-to-github-flavoured-markdown), I did a bit of HTML formatting to make the footnotes look more footnote-y.