### PR TITLE
Create docs folder

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,3 +6,6 @@ aliases:
     - pmorie
     - rgregg
     - lindydonna
+  docs-team:
+    - samodell
+    - richieescarez

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,4 +6,3 @@ aliases:
     - pmorie
     - rgregg
     - lindydonna
-    - jdumars

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Submit a Pull Request to the community sample directory under the Knative
 component folder that aligns with your document. For example, Knative Serving
 samples are under the `serving` folder. A reviewer will be assigned to review
 your submission. They'll work with you to ensure that your submission is clear,
-correct, and meets the [style guide](./DOCS-CONTRIBUTING.md), but it helps if
+correct, and meets the [style guide](./docs/DOCS-CONTRIBUTING.md), but it helps if
 you follow it as you write your tutorial.
 
 ## Meetings and work groups

--- a/docs/DOCS-CONTRIBUTING.md
+++ b/docs/DOCS-CONTRIBUTING.md
@@ -1,6 +1,5 @@
 ---
-title: "Contributing to the Knative documentation"
-linkTitle: "Contributing to docs"
+title: "How to contribute"
 weight: 20
 type: "docs"
 ---

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,0 +1,6 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- docs-team
+reviewers:
+- docs-team

--- a/docs/OWNERS_ALIASES
+++ b/docs/OWNERS_ALIASES
@@ -1,0 +1,4 @@
+aliases:
+  docs-team:
+    - samodell
+    - richieescarez

--- a/docs/OWNERS_ALIASES
+++ b/docs/OWNERS_ALIASES
@@ -1,4 +1,0 @@
-aliases:
-  docs-team:
-    - samodell
-    - richieescarez

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,14 @@
+
+We're excited that you're interested in contributing to the Knative documentation! Check out the resources below to get started.
+
+## Getting started
+
+- [How to contribute](DOCS-CONTRIBUTING.md) -- Contains information about how to contribute and outlines the roles for Docs contributors.
+
+- [Template page](https://raw.githubusercontent.com/knative/community/master/docs/new-page-template.md) -- A blank documentation page that demonstrates how to format a new page and includes tips on structuring your documentation.
+
+## Getting help
+
+- [#docs on the Knative Slack](https://slack.knative.dev) -- The #docs channel is the best place to go if you have questions about making changes to the documentation. We're happy to help!
+
+- [Documentation working group](../WORKING-GROUPS.md#documentation) -- Come join us in the working group to meet other docs contributors and ask any questions you might have.

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Contributing to the Knative documentation"
+linkTitle: "Contributing to the docs"
+weight: 20
+type: "docs"
+---
+
+{{% readfile file="README.md" %}}

--- a/docs/new-page-template.md
+++ b/docs/new-page-template.md
@@ -1,0 +1,73 @@
+---
+# This section is called the "frontmatter" for your page
+title: "Title for your page" # Use sentence case for titles
+#linkTitle: "Link for this page in the sidebar"
+# The linkTitle field (above) is optional; use it to provide a shorter link if your page title is very long
+weight: 10 # This affects the placement of the link in the sidebar on the left. Pages are ordered from top to bottom by weight, lowest to highest.
+type: "docs" # You won't need to update this.
+#aliases:
+#  - /docs/example/redirect/moved-renamed-page
+#  - /docs/another-example
+# Has the page ever moved? If yes, include the prior location above, starting with path from the site root (for example /docs/, /blog/, or /community/). The old URL will redirect to this new file. For a new pages, "aliases" are not required.
+---
+
+This guide shows you how to do something very cool. Make sure to include
+a value proposition for the user: for example, this guide shows you how to do X,
+which is useful for doing Y and Z. Make sure you answer the questions "what does
+this guide show you how to do?" and "why would someone want to do this?".
+
+## Before you begin
+
+You need:
+
+- A Kubernetes cluster with [Knative installed](../install/README.md). <!-- Update this relative link as needed,
+depending on where the new page is located in the file structure. -->
+- Anything else?
+
+## Break steps into logical sections
+
+Avoid nesting headings directly on top of each other with no text inbetween.
+
+1. Use ordered lists for steps.
+
+1. Step number two.
+
+1. Step number three.
+
+<!-- GitHub's markdown processor will correctly automate the numbers in ordered
+	 lists if every list item starts with one. Our site has a known issue with
+	 rendering the numbers in ordered lists (see https://github.com/knative/docs/issues/1202)
+     but we still recommend contributors avoid manually numbered ordered lists. -->
+
+### You can use smaller sections within sections for related tasks
+
+Avoid nesting headings directly on top of each other with no text inbetween.
+
+Put code into a code block. 
+
+1. Here's a code snippet:
+   <!-- Use spaces and not tabs to indent code blocks, and leave one blank line before and after the block. -->
+   ```bash
+   kubectl apply --filename test.yaml
+   ```
+1. Another code snippet:
+
+   ```bash
+   kubectl apply --filename test2.yaml
+   ```
+
+Always explain code snippets thoroughly so that how they work or what they do
+is clear.
+
+## Cleaning up
+
+If your guide installs a sample application, show the user how to delete it.
+
+## What's next
+
+Provide links to other relevant topics, if applicable. Once someone has
+completed these steps, what might they want to do next?
+
+- [Link](./page.md) <!-- Always use relative links if linking to a page within the Docs repo. -->
+- [Link](./page.md)
+- [Link](./page.md)


### PR DESCRIPTION
This moves the information about contributing to the docs to its own separate folder, allowing us to place a template page that had been living in the Docs repo here instead.

From what I understand, having a docs folder should also make it possible for us to be given permissions to approve changes within only the docs folder of the Community repo, so that we can update and maintain that information without needing someone from the Community approvers list to review.

Docs PR: https://github.com/knative/docs/pull/2106