### PR TITLE
Add grantr as Eventing WG lead

### DIFF
--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -125,6 +125,7 @@ Event sources, bindings, FaaS framework, and orchestration
 | ------------------------------------------------------ | ----------- | ------- | ----------------------------------- |
 | <img width="30px" src="https://github.com/vaikas.png"> | Ville Aikas | VMware  | [vaikas](https://github.com/vaikas) |
 | <img width="30px" src="https://github.com/lionelvillard.png"> | Lionel Villard | IBM  | [lionelvillard](https://github.com/lionelvillard) |
+| <img width="30px" src="https://github.com/grantr.png"> | Grant Rodgers | Google  | [grantr](https://github.com/grantr) |
 
 ## Eventing Channels
 


### PR DESCRIPTION
Add Grant Rodgers as Eventing WG technical lead.

[Requirements](https://knative.dev/contributing/roles/#working-group-technical-lead):
- [X] **Recognized as having expertise in the group’s subject matter.**
  - Key contributor to [initial Eventing API design](https://docs.google.com/document/d/1JZtFkz_C3orG9IfDxxGkAmuuGxUQ434ji-rdl3oKObE)
  - Led design and implementation of [Broker and Trigger](https://docs.google.com/document/d/1cRk8dko2zN3CthYwCuC1esZPoW_5roCDHw0K8cd2yVo)
  - Created and currently lead [Eventing Performance Task Force](https://docs.google.com/document/d/1UgblGknPcIMcOfUc_UImUAyjTGTfZNWXZV1_iPsDntY)
  - Designed and implemented (never merged) [Advanced filtering for triggers](https://docs.google.com/presentation/d/1v1XgRJVDL8eMPiWEIdRAWxFOolSxhI5JC3epHnrnwsk)
  - Many other features and improvements

- [X] **Approver for a relevant part of the codebase for at least 3 months.**
  - Approver for eventing since [August 2018](https://github.com/knative/eventing/pull/387) (17 months)

- [X] **Member for at least 6 months.**
  - Since day 1 :smile:

- [X] **Primary reviewer for 20 substantial PRs.**
  - [112 L, XL, XXL in knative/eventing](https://github.com/knative/eventing/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+-author%3Agrantr+reviewed-by%3Agrantr+-label%3Asize%2FS+-label%3Asize%2FXS+-label%3Asize%2FM+)
  - [49 L, XL, XXL in knative/eventing-contrib](https://github.com/knative/eventing-contrib/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+-author%3Agrantr+reviewed-by%3Agrantr+-label%3Asize%2FS+-label%3Asize%2FXS+-label%3Asize%2FM+)
  - Some recent examples in addition to those in https://github.com/knative/eventing/pull/387:
    - https://github.com/knative/eventing-contrib/pull/300
    - https://github.com/knative/eventing/pull/1849
    - https://github.com/knative/eventing/pull/2333
    - https://github.com/knative/eventing/pull/1057
    - https://github.com/knative/eventing/pull/788
    - https://github.com/knative/eventing/pull/2341

- [X] **Reviewed or merged at least 50 PRs.**
  - [283 reviewed](https://github.com/knative/eventing/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+-author%3Agrantr+reviewed-by%3Agrantr+) + [82 merged](https://github.com/knative/eventing/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+author%3Agrantr) in eventing
  - [113 reviewed](https://github.com/knative/eventing-contrib/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+-author%3Agrantr+reviewed-by%3Agrantr+) + [38 merged](https://github.com/knative/eventing-contrib/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+author%3Agrantr) in eventing-contrib

- [ ] Sponsored by the technical oversight committee.

/cc @vaikas
