### PR TITLE
Step down as an Operations WG lead

### DIFF
--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -216,7 +216,6 @@ Managing, assessing system health and maintaining Knative clusters
 
 | &nbsp;                                                     | Leads        | Company | Profile                                     |
 | ---------------------------------------------------------- | ------------ | ------- | ------------------------------------------- |
-| <img width="30px" src="https://github.com/bbrowning.png">  | Ben Browning | Red Hat | [bbrowning](https://github.com/bbrowning)   |
 | <img width="30px" src="https://github.com/houshengbo.png"> | Vincent Hou  | IBM     | [houshengbo](https://github.com/houshengbo) |
 | <img width="30px" src="https://github.com/k4leung4.png">   | Kenny Leung  | Google  | [k4leung4](https://github.com/k4leung4)     |
 


### PR DESCRIPTION
Kenny and Vincent have been doing most of the heavy lifting of leading the Operations Working Group for a while now. While I'm still very invested in Knative itself, I do not have the necessary time to devote to this role. I've spoken to them offline about this, but just making it official.

cc @k4leung4 @houshengbo