### PR TITLE
Add Dave Protasowski as Serving API Core WG technical lead.

### DIFF
--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -64,10 +64,10 @@ API
 | Document Folder            | [Folder](https://drive.google.com/corp/drive/folders/1fpBW7VyiBISsKuVdgn1MrgFdtx_JGoC5)                                                                       |
 | Slack Channel              | [#serving-api](https://slack.knative.dev/messages/serving-api)                                                                                                |
 
-| &nbsp;                                                   | Leads           | Company | Profile                                 |
-| -------------------------------------------------------- | --------------- | ------- | --------------------------------------- |
-| <img width="30px" src="https://github.com/mattmoor.png"> | Matt Moore      | VMware  | [mattmoor](https://github.com/mattmoor) |
-| <img width="30px" src="https://github.com/dgerd.png">    | Dan Gerdesmeier | Google  | [dgerd](https://github.com/dgerd)       |
+| &nbsp;                                                   | Leads             | Company | Profile                                 |
+| -------------------------------------------------------- | ----------------- | ------- | --------------------------------------- |
+| <img width="30px" src="https://github.com/mattmoor.png"> | Matt Moore        | VMware  | [mattmoor](https://github.com/mattmoor) |
+| <img width="30px" src="https://github.com/dprotaso.png"> | Dave  Protasowski | Pivotal | [dprotaso](https://github.com/dprotaso) |
 
 ## Client
 


### PR DESCRIPTION
[Requirements](https://knative.dev/contributing/roles/#working-group-technical-lead):
- [X] **Recognized as having expertise in the group’s subject matter.**
  - Led the implementation of Conversion Webhook support for knative/serving.
  - Participated in the v1beta1/v1 API task force.
  - Many other features and improvements

- [X] **Approver for a relevant part of the codebase for at least 3 months.**
  - Approver for serving API since [June 2019](https://github.com/knative/serving/pull/4426)

- [X] **Member for at least 6 months.**
  - One of the earliest Knative (FKA Elafros) contributors!

- [X] **Primary reviewer for 20 substantial PRs.**
  - [47 L, XL, XXL in knative/serving](https://github.com/knative/serving/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+-author%3Adprotaso+reviewed-by%3Adprotaso+-label%3Asize%2FS+-label%3Asize%2FXS+-label%3Asize%2FM+)
  - [4 L, XL, XXL in knative/pkg](https://github.com/knative/pkg/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+-author%3Adprotaso+reviewed-by%3Adprotaso+-label%3Asize%2FS+-label%3Asize%2FXS+-label%3Asize%2FM+)

- [X] **Reviewed or merged at least 50 PRs.**
  - [67 reviewed](https://github.com/knative/serving/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+-author%3Adprotaso+reviewed-by%3Adprotaso+) + [58 merged](https://github.com/knative/serving/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+author%3Adprotaso) in serving
  - [10 reviewed](https://github.com/knative/pkg/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+-author%3Adprotaso+reviewed-by%3Adprotaso+) + [23 merged](https://github.com/knative/pkg/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+author%3Adprotaso) in pkg

- [X] Sponsored by the technical oversight committee.

/cc vaikas evankanderson

> NOTE: This also removes @dgerd who announced last week that he plans to step down :(