### PR TITLE
Update meeting schedule for client WG

### DIFF
--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -78,7 +78,7 @@ conventions
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Forum                      | [knative-dev@](https://groups.google.com/forum/#!forum/knative-dev)                                                                                                        |
 | Community Meeting VC       | See the top of the [Meeting notes](https://docs.google.com/document/d/1Uh7jTWQruBBmic-WmTvtc9cMF95kQrKb5lsqWhNuikM/edit)                                                   |
-| Community Meeting Calendar | Tuesdays 10:30a-11:00a Pacific <br>[Calendar Invitation](https://calendar.google.com/calendar/embed?src=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com) |
+| Community Meeting Calendar | Tuesdays, alternating between 10:30a-11:00a Pacific and 3:30p-4:00p Central European every two weeks<br>[Calendar Invitation](https://calendar.google.com/calendar/embed?src=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com) |
 | Meeting Notes              | [Notes](https://docs.google.com/document/d/1Uh7jTWQruBBmic-WmTvtc9cMF95kQrKb5lsqWhNuikM/edit)                                                                              |
 | Document Folder            | [Folder](https://drive.google.com/corp/drive/folders/1QF-job3rCEqCpJLm8nHkC4mBIi4XANE1)                                                                                    |
 | Slack Channel              | [#cli](https://slack.knative.dev)                                                                                                                                          |


### PR DESCRIPTION
The client working group decided to move to an alternating schedule
for the WG calls, so that people from APAC region can join, too.
For reasoning and the community poll, please see https://github.com/knative/client/issues/740
(and also the client WG call protocols).
So ecery odd-numbered week (like this week, which is calendar week 13),
the current timeslot is active, on every other week we want to try
out 3:30pm Central European time (CET or CEST)

Beside this PR, would it be possible to adapt the Knative calendar, too ?
Although we settled on an European timezone for the second timeslot,
as a good approximation we can also use 6:30am Pacific Time.