### PR TITLE
Fix the link to `DOCS-CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ later join knative-dev if you want immediate access).
 ## Contributing documentation
 
 For more information about contributing to the Knative documentation, see
-[DOCS-CONTRIBUTING.md](./DOCS-CONTRIBUTING.md). A lot of the information on this
+[DOCS-CONTRIBUTING.md](./docs/DOCS-CONTRIBUTING.md). A lot of the information on this
 page still applies, but you'll find the specifics about the docs process there.
 
 ## Contributing a feature


### PR DESCRIPTION
it seems that the file got moved to the `docs/` folder but the link was not updated.