### PR TITLE
Remove WORKING-GROUPS.md link to remove duplicate headings from website.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ given the same level of review.
 ## Working groups
 
 The Knative contributors community is organized into a set of
-[working groups](./WORKING-GROUPS.md). Any contribution to Knative should be
+[working groups](./working-groups/WORKING-GROUPS.md). Any contribution to Knative should be
 started by first engaging with the appropriate working group.
 
 ## Code of conduct

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Other Documents
 - [Values](./VALUES.md) - shared goals and values for the community
 - [Contributing to Knative](./CONTRIBUTING.md) - guidelines and advice on
   becoming a contributor
-- [Working Groups](./WORKING-GROUPS.md) - describes our various working groups
+- [Working Groups](./working-groups/WORKING-GROUPS.md) - describes our various working groups
 - [Working Group Processes](./mechanics/WORKING-GROUP-PROCESSES.md) - describes how
   working groups operate
 - [Steering Committee](./STEERING-COMMITTEE.md) - describes our steering
@@ -73,7 +73,7 @@ you follow it as you write your tutorial.
 
 Knative has public and recorded bi-weekly community meetings.
 
-Each project has one or more [working groups](./WORKING-GROUPS.md) driving the
+Each project has one or more [working groups](./working-groups/WORKING-GROUPS.md) driving the
 project, and Knative as a single
 [technical oversight community](./TECH-OVERSIGHT-COMMITTEE.md) monitoring the
 overall project.

--- a/SLACK-GUIDELINES.md
+++ b/SLACK-GUIDELINES.md
@@ -59,7 +59,7 @@ a member of the [KSC](STEERING-COMMITTEE.md) or
 Please reach out to the #slack-admins group with your request to create a new
 channel.
 
-Channels are dedicated to [Working Groups](./WORKING-GROUPS.md), sub-projects,
+Channels are dedicated to [Working Groups](./working-groups/WORKING-GROUPS.md), sub-projects,
 community topics, and related programs/projects.
 
 Channels are not:

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -31,7 +31,7 @@ the way we run this committee, based on feedback from the community.
 1. Define and evolve project governance structures and policies, including
    project roles and how collaborators become members, approvers, leads, and/or
    administrators. This includes policy for the creation and administration of
-   [working groups](./WORKING-GROUPS.md) and committees.
+   [working groups](./working-groups/WORKING-GROUPS.md) and committees.
 1. Steward, control access, delegate access, and establishes processes
    regarding, all Knative project resources and has the final say in the
    disposition of those resources.

--- a/WORKING-GROUPS.md
+++ b/WORKING-GROUPS.md
@@ -1,1 +1,0 @@
-working-groups/WORKING-GROUPS.md

--- a/docs/DOCS-CONTRIBUTING.md
+++ b/docs/DOCS-CONTRIBUTING.md
@@ -64,7 +64,7 @@ see a problem with the documentation, submit an issue using the following steps:
      When you create a bug report, include as many details as possible and
      include suggested fixes to the issue. If you know which Knative component
      your bug is related to, you can assign the appropriate
-     [Working Group Lead](../WORKING-GROUPS.md).
+     [Working Group Lead](../working-groups/WORKING-GROUPS.md).
    - **Feature request**: For upcoming changes to the documentation or requests
      for more information on a particular subject.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,4 +11,4 @@ We're excited that you're interested in contributing to the Knative documentatio
 
 - [#docs on the Knative Slack](https://slack.knative.dev) -- The #docs channel is the best place to go if you have questions about making changes to the documentation. We're happy to help!
 
-- [Documentation working group](../WORKING-GROUPS.md#documentation) -- Come join us in the working group to meet other docs contributors and ask any questions you might have.
+- [Documentation working group](../working-groups/WORKING-GROUPS.md#documentation) -- Come join us in the working group to meet other docs contributors and ask any questions you might have.

--- a/mechanics/WORKING-GROUP-PROCESSES.md
+++ b/mechanics/WORKING-GROUP-PROCESSES.md
@@ -102,7 +102,7 @@ working group:
   these meetings between 9:00AM to 2:59PM Pacific Time. Invite the public Google
   group to the meeting.
 
-- **Register the Working Group**. Go to [WORKING-GROUPS.md](./WORKING-GROUPS.md)
+- **Register the Working Group**. Go to [WORKING-GROUPS.md](../working-groups/WORKING-GROUPS.md)
   and add your working group name, the names of the leads, the working group
   charter, and a link to the meeting you created.
 


### PR DESCRIPTION
Fixes up all the links to be relative to the new location for `working-groups/WORKING-GROUPS.md`, and deletes the old link, which results in a duplicate side-heading at https://knative.dev/community/contributing/working-groups/ and https://knative.dev/community/contributing/working-groups/working-groups/

/assign @rgregg 