### PR TITLE
Add April Kyle Nassi to Steering

### DIFF
--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -87,12 +87,12 @@ first name):
 
 | &nbsp;                                                     | Member           | Organization | Profile                                      |
 | ---------------------------------------------------------- | ---------------- | ------------ | -------------------------------------------- |
+| <img width="30px" src="https://github.com/thisisnotapril.png"> | April Kyle Nassi      | Google       | [@thisisnotapril](https://github.com/thisisnotapril) |
 | <img width="30px" src="https://github.com/bsnchan.png">    | Brenda Chan      | VMware       | [@bsnchan](https://github.com/bsnchan)       |
 | <img width="30px" src="https://github.com/mbehrendt.png">  | Michael Behrendt | IBM          | [@mbehrendt](https://github.com/mbehrendt)   |
 | <img width="30px" src="https://github.com/pmorie.png">     | Paul Morie       | Red Hat      | [@pmorie](https://github.com/pmorie)         |
 | <img width="30px" src="https://github.com/rgregg.png">     | Ryan Gregg       | Google       | [@rgregg](https://github.com/rgregg)         |
 | <img width="30px" src="https://github.com/isdal.png">      | Tomas Isdal      | Google       | [@isdal](https://github.com/isdal)           |
-|  | Open *      | Google       |  |
 |  | Open *      | Google       |  |
 
 * Open seats have been allocated to the organization per the committee rules, but have not been assigned to a member of the organization.


### PR DESCRIPTION
Per nomination from Google and a unanimous vote of the steering committee, @thisisnotapril is appointed to the Knative Steering Committee.