### PR TITLE
Ryan Gregg resignation from Steering

### DIFF
--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -92,9 +92,10 @@ first name):
 | <img width="30px" src="https://github.com/bsnchan.png">    | Brenda Chan      | VMware       | [@bsnchan](https://github.com/bsnchan)       |
 | <img width="30px" src="https://github.com/mbehrendt.png">  | Michael Behrendt | IBM          | [@mbehrendt](https://github.com/mbehrendt)   |
 | <img width="30px" src="https://github.com/pmorie.png">     | Paul Morie       | Red Hat      | [@pmorie](https://github.com/pmorie)         |
-| <img width="30px" src="https://github.com/rgregg.png">     | Ryan Gregg       | Google       | [@rgregg](https://github.com/rgregg)         |
 | <img width="30px" src="https://github.com/isdal.png">      | Tomas Isdal      | Google       | [@isdal](https://github.com/isdal)           |
 |  | Open \*      | Google       |  |
+|  | Open \*      | Google       |  |
+
 
 \* Open seats have been allocated to the organization per the committee rules,
   but have not been assigned to a member of the organization.


### PR DESCRIPTION
My last day at Google is Friday, May 8th. 
Since my steering committee seat is assigned to Google, I am resigning my seat on the committee.

It's been wonderful working with the Knative community for the last two years to make Knative into what it is today, and I have a lot of excitement about where Knative is going in the future.

Thank you to everyone who has help made Knative fantastic. Best wishes!