### PR TITLE
Add knative-prow-robot as an org admin

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -17,6 +17,7 @@ orgs:
     - googlebot
     - grantr
     - isdal
+    - knative-prow-robot
     - markusthoemmes
     - mattmoor
     - mbehrendt

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -15,6 +15,7 @@ orgs:
     - googlebot
     - grantr
     - isdal
+    - knative-prow-robot
     - markusthoemmes
     - mattmoor
     - mbehrendt


### PR DESCRIPTION
Add `knative-prow-robot` as an org admin for `knative` and `knative-sandbox`, so it has enough permissions to run `peribolos` jobs.

/assign @evankanderson

Please note this permission will have to be manually set for the first time.