### PR TITLE
Re-add Harwayne (WG lead) who was removed in the great absent user scrub of 2020

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -91,6 +91,7 @@ orgs:
     - gsiener
     - gyliu513
     - halvards
+    - Harwayne
     - hev
     - houshengbo
     - ian-mi


### PR DESCRIPTION
I cleared out all the "org" members who hadn't accepted earlier invites, on the theory that:

1. They were probably not that interested in the repo.
1. They could re-add to the org easily with a PR if they did want access later.
1. GitHub is so spammy they probably would keep missing the invite.

Unfortunately, Adam hadn't accepted the invite, and team members must be org members, so we need to re-add him (or remove him from the WG lists).