### PR TITLE
Add two users who were added manually after #135

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -73,6 +73,7 @@ orgs:
     - bendory
     - Benjamintf1
     - BenTheElder
+    - bharattkukreja
     - biilmann
     - bikramnehra
     - billimek
@@ -434,6 +435,7 @@ orgs:
     - timothyshelton
     - tliberman
     - tmatsuo
+    - tommyreddad
     - tomwalter
     - topherbullock
     - tricky42


### PR DESCRIPTION
With this PR, the diff for the `knative` org is clean except for some team title / wiki cleanups.