### PR TITLE
Add two milestone maintainers which were added after #135

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -813,6 +813,8 @@ orgs:
         - chaodaiG
         - akashrv
         - vaikas
+        - shashwathi
+        - eallred-google
         privacy: closed
       Observability Writers:
         description: Grants write access to observability-related repositories.


### PR DESCRIPTION
I missed these earlier due to peribolos noise, but caught them when reviewing the GitHub audit log.