### PR TITLE
Add Cris Zong to the Knative org

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -364,7 +364,6 @@ orgs:
         - k4leung4
         - chaodaiG
         - akashrv
-        privacy: closed
       Observability Writers:
         description: Grants write access to observability-related repositories.
         privacy: closed

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -472,6 +472,7 @@ orgs:
     - xtremerui
     - yanweiguo
     - yaron2
+    - yizong98
     - yoav
     - yolocs
     - yt3liu


### PR DESCRIPTION
Cris is a new summer intern in Google, and will be working on Knative during these three months.

And by the way fix one syntax error in the `knative-sandbox.yaml` file as the key is duplicated.