### PR TITLE
Add Ashleigh as Docs WG lead

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -281,6 +281,7 @@ orgs:
             description: The Working Group leads for Docs
             members:
             - samodell
+	    - abrennan89
             privacy: closed
       Eventing Writers:
         description: Grants write access to eventing-related repositories.

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -281,7 +281,7 @@ orgs:
             description: The Working Group leads for Docs
             members:
             - samodell
-	    - abrennan89
+            - abrennan89
             privacy: closed
       Eventing Writers:
         description: Grants write access to eventing-related repositories.

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -668,7 +668,7 @@ orgs:
             description: The Working Group leads for Docs
             members:
             - samodell
-	    - abrennan89
+            - abrennan89
             privacy: closed
           TBD Google tech writers:
             description: Temporary group at the request of Google tech writers.

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -668,6 +668,7 @@ orgs:
             description: The Working Group leads for Docs
             members:
             - samodell
+	    - abrennan89
             privacy: closed
           TBD Google tech writers:
             description: Temporary group at the request of Google tech writers.

--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -113,7 +113,7 @@ Knative documentation, especially the [Docs](../docs/README.md) repo.
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Forum                      | [knative-docs@](https://groups.google.com/forum/#!forum/knative-docs)                                                                                                                                   |
 | Community Meeting VC       | See the top of the [Meeting notes](https://docs.google.com/document/d/1Y7rug0XshcQPdKzptdWbQLQjcjgpFdLeEgP1nfkDAe4/edit)                                                                                |
-| Community Meeting Calendar | Weekly on Tuesdays, alternating between 9:00-9:30am and 4:30-5:00pm PST<br>[Calendar](https://calendar.google.com/calendar/embed?src=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com) |
+| Community Meeting Calendar | Bi Weekly on Tuesdays, 9:00-9:30am<br>[Calendar](https://calendar.google.com/calendar/embed?src=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com) |
 | Meeting Notes              | [Notes](https://docs.google.com/document/d/1Y7rug0XshcQPdKzptdWbQLQjcjgpFdLeEgP1nfkDAe4/edit)                                                                                                           |
 | Document Folder            | [Folder](https://drive.google.com/corp/drive/folders/1K5cM9m-b93ySI5WGKalJKbBq_cfjyi-y)                                                                                                                 |
 | Slack Channel              | [#docs](https://slack.knative.dev/messages/docs)                                                                                                                                                        |
@@ -121,6 +121,7 @@ Knative documentation, especially the [Docs](../docs/README.md) repo.
 | &nbsp;                                                   | Leads      | Company | Profile                                 |
 | -------------------------------------------------------- | ---------- | ------- | --------------------------------------- |
 | <img width="30px" src="https://github.com/samodell.png"> | Sam O'Dell | Google  | [samodell](https://github.com/samodell) |
+| <img width="30px" src="https://github.com/abrennan89.png"> | Ashleigh Brennan | Red Hat  | [abrennan89](https://github.com/abrennan89) |
 
 ## Eventing
 


### PR DESCRIPTION
As discussed in the 9 July 2020 TOC meeting.

Ashleigh has been leading the docs WG de facto for a while while @samodell was on leave, and @carieshmarie said that Sam was talking about recommending her for WG lead before she left.

/assign @mattmoor @markusthoemmes @grantr @tcnghia 