### PR TITLE
docs: fix broken link

### DIFF
--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -9,7 +9,7 @@ aliases:
 
 Most community activity is organized into _working groups_.
 
-Working groups follow the [contributing](./CONTRIBUTING.md) guidelines although
+Working groups follow the [contributing](../CONTRIBUTING.md) guidelines although
 each of these groups may operate a little differently depending on their needs
 and workflow.
 


### PR DESCRIPTION
It looks like with file movements back at
8ca15d2ff226a5ce3b1b7ea6a7b4be8609e6b4af the WORKING-GROUPS.md file's
relative link to the CONTRIBUTING.md is off one directory.  That's
now one level up.

Signed-off-by: Tim Pepper <tpepper@vmware.com>