### PR TITLE
Fix the peribolos configuration file for knative-sandbox

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -227,7 +227,7 @@ orgs:
       discovery:
         allow_merge_commit: false
         allow_rebase_merge: false
-        description: Enable interactions with a cluster and its resources: built-in types, CRDs and COs.
+        description: "Enable interactions with a cluster and its resources: built-in types, CRDs and COs."
         has_projects: true
         has_wiki: false
       eventing-kafka:


### PR DESCRIPTION
The error log for the peribolos Prow job is https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-sandbox-peribolos/1282359710120415233#1:build-log.txt%3A2, the error is `error converting YAML to JSON: yaml: line 230: mapping values are not allowed in this context`.
