### PR TITLE
Remove urasoko from peribolos config file to get rid of the job error

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -200,7 +200,6 @@ orgs:
     - troytop
     - trshafer
     - tzununbekov
-    - urasoko
     - uwefassnacht
     - vagababov
     - vaikas


### PR DESCRIPTION
For unknown reason, the peribolos Prow job is failing when it processes `urasoko` as a member, and removing this person will resolve this error.

See https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-sandbox-peribolos/1283169654633664513 and https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-sandbox-peribolos-test/1283171920660926465.

/cc @mattmoor 