### PR TITLE
Remove urasoko from the configuration file to fix the Knative peribolos Prow job

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -451,7 +451,6 @@ orgs:
     - tysonnorris
     - tzununbekov
     - univ0298
-    - urasoko
     - uwefassnacht
     - vagababov
     - vaikas


### PR DESCRIPTION
It's the same issue as https://github.com/knative/community/issues/186.

They also fail the peribolos Prow job for Knative org.

/assign @mattmoor 