### PR TITLE
Propose to add Jon Donovan as the lead of the Operator WG

### DIFF
--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -217,6 +217,7 @@ Managing, assessing system health and maintaining Knative clusters
 | &nbsp;                                                     | Leads        | Company | Profile                                     |
 | ---------------------------------------------------------- | ------------ | ------- | ------------------------------------------- |
 | <img width="30px" src="https://github.com/houshengbo.png"> | Vincent Hou  | IBM     | [houshengbo](https://github.com/houshengbo) |
+| <img width="30px" src="https://github.com/cynocracy.png">  | Jon Donovan  | Google  | [cynocracy](https://github.com/cynocracy)   |
 
 ## Scaling
 


### PR DESCRIPTION
Facing challenges, someone chooses to retreat. Confronting uncertainties, someone chooses to leave.

Jon Donovan is not one of them. He is willing to step up and take the responsibilities, battling against all obstacles and frustrations. He has been actively participating all the operator's activities for over six months. I appreciate his support, vision and effort.

