### PR TITLE
Include knative-sandbox/eventing-kafka-broker repo in Knative Admin list

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -364,6 +364,7 @@ orgs:
           build-spike: admin
           discovery: admin
           eventing-kafka: admin
+          eventing-kafka-broker: admin
           eventing-rabbitmq: admin
           net-certmanager: admin
           net-contour: admin


### PR DESCRIPTION
knative-prow-releaser-robot does not have branching permissions on the described repo:
https://storage.googleapis.com/knative-prow/logs/ci-knative-sandbox-eventing-kafka-broker-auto-release/1296147964753874944/build-log.txt
```
remote: Permission to knative-sandbox/eventing-kafka-broker.git denied to knative-prow-releaser-robot.
fatal: unable to access 'https://05635dbd65a7b695fa7a6e55f93c84e5962d8928@github.com/knative-sandbox/eventing-kafka-broker/': The requested URL returned error: 403
```