### PR TITLE
Document release schedule for the next 9 months

### DIFF
--- a/mechanics/RELEASE-SCHEDULE.md
+++ b/mechanics/RELEASE-SCHEDULE.md
@@ -1,0 +1,16 @@
+# Knative Release Schedule
+
+Knative releases every 6 weeks. As much as possible, releases should be driven by automation, and repos should be ready to release at any point. It should also be possible to produce and consume nightly artifacts.
+
+With that said, it can be useful to have a list of when future releases will happen, so this document provides a schedule for the next 6+ months of releases.
+
+| Release | Date |
+| ------- | ---- |
+| 0.17    | 2020-08-18 |
+| 0.18    | 2020-09-29 |
+| 0.19    | 2020-11-10 |
+| 0.20    | 2020-01-05 ** Moved by 2 weeks for end of year holidays** |
+| 0.21    | 2020-02-02 |
+| 0.22    | 2020-03-16 |
+| 0.23    | 2020-04-27 |
+| 0.24    | 2020-06-08 |

--- a/mechanics/RELEASE-SCHEDULE.md
+++ b/mechanics/RELEASE-SCHEDULE.md
@@ -10,7 +10,7 @@ With that said, it can be useful to have a list of when future releases will hap
 | 0.18    | 2020-09-29 |
 | 0.19    | 2020-11-10 |
 | 0.20    | 2020-01-05 ** Moved by 2 weeks for end of year holidays** |
-| 0.21    | 2020-02-02 |
-| 0.22    | 2020-03-16 |
-| 0.23    | 2020-04-27 |
-| 0.24    | 2020-06-08 |
+| 0.21    | 2020-02-16 |
+| 0.22    | 2020-03-30 |
+| 0.23    | 2020-05-11 |
+| 0.24    | 2020-06-22 |


### PR DESCRIPTION
Because it can be a pain to look this up, and because we are talking about moving the December release by 1-2 weeks.

Fixes #216 