### PR TITLE
Add wg-repository template for new repos

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -301,6 +301,12 @@ orgs:
         description: A template project for writing your own Knative eventing source.
         has_projects: true
         has_wiki: false
+      wg-repository:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        description: "Template for WG-owned repositories."
+        has_projects: true
+        has_wiki: false
     teams:
       Client Writers:
         description: Grants write access to client-related repositories.

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -379,6 +379,7 @@ orgs:
           net-kourier: admin
           sample-controller: admin
           sample-source: admin
+          wg-repository: admin
         teams:
           Knative Robots:
             description: Contains robots and only robots.


### PR DESCRIPTION
Fixes #239

https://github.com/knative-sandbox/wg-repository

Includes README, OWNERS files, COC, and test skeleton ready for first PR.