### PR TITLE
Git Hub Action - downstream-test-go

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -240,6 +240,12 @@ orgs:
         description: "Enable interactions with a cluster and its resources: built-in types, CRDs and COs."
         has_projects: true
         has_wiki: false
+      downstream-test-go:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        description: A Github Action for Knative to test downstream repos upgradability from upstream repos.
+        has_projects: true
+        has_wiki: false
       eventing-kafka:
         allow_merge_commit: false
         allow_rebase_merge: false
@@ -363,6 +369,7 @@ orgs:
           .github: admin
           build-spike: admin
           discovery: admin
+          downstream-test-go: admin
           eventing-kafka: admin
           eventing-kafka-broker: admin
           eventing-rabbitmq: admin

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -450,6 +450,7 @@ orgs:
         privacy: closed
         repos:
           .github: write
+          downstream-test-go: write
         teams:
           Productivity WG Leads:
             description: The Working Group leads for Productivity


### PR DESCRIPTION
adding a repo to create a custom github action for knative to test downstream repos upgradability from upstream repos.