### PR TITLE
Make it so the folks doing github actions exploring in sandbox can make releases

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -480,13 +480,9 @@ orgs:
         repos:
           .github: admin
           downstream-test-go: admin
-        teams:
-          Git Hub Action Leads:
-            description: The leads for GitHub Actions for Knative
-            members:
-            - n3wscott
-            - mattmoor
-            privacy: closed
+        members:
+        - n3wscott
+        - mattmoor
       Serving Writers:
         description: Grants write access to serving-related repositories.
         privacy: closed

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -474,6 +474,19 @@ orgs:
             - chizhg
             - chaodaiG
             privacy: closed
+      GitHub Actions Effort:
+        description: Grants admin rights to github actions related repositories.
+        privacy: closed
+        repos:
+          .github: admin
+          downstream-test-go: admin
+        teams:
+          Git Hub Action Leads:
+            description: The leads for GitHub Actions for Knative
+            members:
+            - n3wscott
+            - mattmoor
+            privacy: closed
       Serving Writers:
         description: Grants write access to serving-related repositories.
         privacy: closed

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -475,6 +475,11 @@ orgs:
             - chaodaiG
             privacy: closed
       GitHub Actions Effort:
+        # The maintainers of the GitHub Actions for Knative effort need to
+        # create releases to allow the versioning control used by actions work.
+        # At the moment this is not automated so granting admin rights to the
+        # set of developers on the actions. This can be removed when we can
+        # automate the releasing of actions.
         description: Grants admin rights to github actions related repositories.
         privacy: closed
         repos:


### PR DESCRIPTION
Sandbox is intended to be a little less structured that core Knative. In working with github actions, I need to be able to make releases, but I am not a member of productivity. Making a new group to have admin over the `.github` and `github actions` related repos in `knative-sandbox`.