### PR TITLE
Removes past steering members from owners file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,11 +1,8 @@
 aliases:
   steering-committee:
     - bsnchan
-    - isdal
     - mbehrendt
     - pmorie
-    - rgregg
-    - lindydonna
   docs-team:
     - samodell
     - richieescarez


### PR DESCRIPTION
This PR removes past steering members from the owners file. #191 addresses adding the new steering members (pending them accepting their github invitation).