### PR TITLE
Make projected minimum kubernetes versions more true

### DIFF
--- a/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
+++ b/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
@@ -878,7 +878,7 @@ tuple
    </td>
    <td rowspan="2" >2021-06-08
    </td>
-   <td rowspan="2" >1.19.x
+   <td rowspan="2" >(undetermined)
    </td>
    <td rowspan="2" >v1
    </td>
@@ -906,7 +906,7 @@ tuple
    </td>
    <td rowspan="2" >2021-03-16
    </td>
-   <td rowspan="2" >1.19.x
+   <td rowspan="2" >(undetermined)
    </td>
    <td rowspan="2" >v1
    </td>
@@ -934,7 +934,7 @@ tuple
    </td>
    <td rowspan="3" >2021-02-02
    </td>
-   <td rowspan="3" >1.17.x
+   <td rowspan="3" >1.16.x
    </td>
    <td rowspan="3" >v1
    </td>

--- a/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
+++ b/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
@@ -235,7 +235,7 @@ tuple
    </td>
    <td rowspan="3" >2021-06-08
    </td>
-   <td rowspan="3" >1.19.x
+   <td rowspan="3" >(undetermined)
    </td>
    <td rowspan="3" >v1
    </td>
@@ -271,7 +271,7 @@ tuple
    </td>
    <td rowspan="3" >2021-04-27
    </td>
-   <td rowspan="3" >1.19.x
+   <td rowspan="3" >(undetermined)
    </td>
    <td rowspan="3" >v1
    </td>
@@ -307,7 +307,7 @@ tuple
    </td>
    <td rowspan="3" >2021-03-16
    </td>
-   <td rowspan="3" >1.19.x
+   <td rowspan="3" >(undetermined)
    </td>
    <td rowspan="3" >v1
    </td>
@@ -343,7 +343,7 @@ tuple
    </td>
    <td rowspan="3" >2021-02-02
    </td>
-   <td rowspan="3" >1.17.x
+   <td rowspan="3" >1.16.x
    </td>
    <td rowspan="3" >v1
    </td>


### PR DESCRIPTION
- knative 0.17 minimum kubernetes version is 1.16.
- future minimum version may be 1.17, but we're not sure yet. It definitely won't be 1.19 by knative 0.18, though. For now it seems better to say "(undetermined)" than for this to be actively wrong.

/assign @mattmoor @vaikas 