### PR TITLE
Add Harwayne to Eventing Triage

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -684,6 +684,7 @@ orgs:
             - akashrv
             - slinkydeveloper
             - n3wscott
+            - Harwayne
             privacy: closed
           Eventing WG Leads:
             description: The Working Group leads for Eventing


### PR DESCRIPTION
Add Harwayne to 'Eventing Triage', following the instructions in https://github.com/knative/eventing/blob/master/support/COMMUNITY_CONTACTS.md as the weekly contact for Sep 21-27.