### PR TITLE
Fix peribolos config file for Knative by removing jessiezcc

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -789,7 +789,6 @@ orgs:
         - dwnusbaum
         - eallred-google
         - igsong
-        - jessiezcc
         - josephburnett
         - julz
         - k4leung4


### PR DESCRIPTION
The error is `Configuration failed: failed to configure knative members: all team members/maintainers must also be org members: jessiezcc`, see https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-peribolos/1309538632675102723#1:build-log.txt%3A8

/cc @mattmoor 