### PR TITLE
add eventing-autoscaler-keda to eventing writers

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -418,6 +418,7 @@ orgs:
         description: Grants write access to eventing-related repositories.
         privacy: closed
         repos:
+          eventing-autoscaler-keda: write
           eventing-awssqs: write
           eventing-camel: write
           eventing-ceph: write
@@ -464,6 +465,7 @@ orgs:
           build-spike: admin
           discovery: admin
           downstream-test-go: admin
+          eventing-autoscaler-keda: admin
           eventing-awssqs: admin
           eventing-camel: admin
           eventing-ceph: admin


### PR DESCRIPTION
Was blocked on releasing Autoscaler-Keda during the 0.18 release, this corrects that.