### PR TITLE
chaodaiG step down as productivity WG lead

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -582,7 +582,6 @@ orgs:
             description: The Working Group leads for Productivity
             members:
             - chizhg
-            - chaodaiG
             privacy: closed
       GitHub Actions Effort:
         # The maintainers of the GitHub Actions for Knative effort need to

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -826,7 +826,6 @@ orgs:
             description: The Working Group leads for Productivity
             members:
             - chizhg
-            - chaodaiG
             privacy: closed
       Serving Writers:
         description: Grants write access to serving-related repositories.

--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -252,7 +252,6 @@ performance/scale/load testing infrastructure
 
 | &nbsp;                                                    | Leads         | Company | Profile                                   |
 | --------------------------------------------------------- | ------------- | ------- | ----------------------------------------- |
-| <img width="30px" src="https://github.com/chaodaiG.png">  | Chao Dai      | Google  | [chaodaiG](https://github.com/chaodaiG)   |
 | <img width="30px" src="https://github.com/chizhg.png">    | Chi Zhang     | Google  | [chizhg](https://github.com/chizhg)       |
 
 ---


### PR DESCRIPTION
Haven't been able to focusing on driving knative productivity for a few months now, and probably won't be able to make much time for it in the near future either. Will still be around and can help, just will not be as engaged.

/cc @chizhg 