### PR TITLE
Fix release schedule's year

### DIFF
--- a/mechanics/RELEASE-SCHEDULE.md
+++ b/mechanics/RELEASE-SCHEDULE.md
@@ -9,8 +9,8 @@ With that said, it can be useful to have a list of when future releases will hap
 | 0.17    | 2020-08-18 |
 | 0.18    | 2020-09-29 |
 | 0.19    | 2020-11-10 |
-| 0.20    | 2020-01-05 ** Moved by 2 weeks for end of year holidays** |
-| 0.21    | 2020-02-16 |
-| 0.22    | 2020-03-30 |
-| 0.23    | 2020-05-11 |
-| 0.24    | 2020-06-22 |
+| 0.20    | 2021-01-05 ** Moved by 2 weeks for end of year holidays** |
+| 0.21    | 2021-02-16 |
+| 0.22    | 2021-03-30 |
+| 0.23    | 2021-05-11 |
+| 0.24    | 2021-06-22 |


### PR DESCRIPTION
This patch fixes "2020" in the release schedule.
Without this patch, we cannot break 2020 loop.

/cc @evankanderson @tcnghia 