### PR TITLE
Add kn-plugin-source-kafka to the peribolos sandbox config

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -341,6 +341,12 @@ orgs:
         description: Kn plugin for managing a Kubernetes based Knative installation.
         has_projects: true
         has_wiki: false
+      kn-plugin-source-kafka:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        description: Kn plugin for managing Kafka event sources.
+        has_projects: true
+        has_wiki: false
       kn-plugin-source-pkg:
         allow_merge_commit: false
         allow_rebase_merge: false
@@ -427,6 +433,7 @@ orgs:
         repos:
           build-spike: write
           kn-plugin-admin: write
+          kn-plugin-source-kafka: write
           kn-plugin-source-pkg: write
           kn-plugin-diag: write
         teams:
@@ -512,6 +519,7 @@ orgs:
           eventing-rabbitmq: admin
           eventing-redis: admin
           kn-plugin-admin: admin
+          kn-plugin-source-kafka: admin
           kn-plugin-source-pkg: admin
           kn-plugin-diag: admin
           knobots: admin


### PR DESCRIPTION
In order to new a repo `kn-plugin-source-kafka` under knative sandbox, I create this PR, including:
- Add the repository and a description.
- Grant Knative Admin the admin privilege.
- Grant the sponsoring WG the write privilege.

Refer to https://github.com/knative/community/issues/330