### PR TITLE
Add knative-automation to knative and knative-sandbox

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -17,7 +17,6 @@ orgs:
     - google-admin
     - googlebot
     - grantr
-    - knative-automation
     - knative-prow-robot
     - markusthoemmes
     - mattmoor
@@ -128,6 +127,7 @@ orgs:
     - julz
     - jzelinskie
     - k4leung4
+    - knative-automation
     - knative-metrics-robot
     - knative-prow-releaser-robot
     - knative-test-reporter-robot

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -17,6 +17,7 @@ orgs:
     - google-admin
     - googlebot
     - grantr
+    - knative-automation
     - knative-prow-robot
     - markusthoemmes
     - mattmoor

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -15,7 +15,6 @@ orgs:
     - google-admin
     - googlebot
     - grantr
-    - knative-automation
     - knative-prow-robot
     - markusthoemmes
     - mattmoor
@@ -271,6 +270,7 @@ orgs:
     - kimikowang
     - kimsterv
     - kitmerker-jfrog
+    - knative-automation
     - knative-metrics-robot
     - knative-prow-releaser-robot
     - knative-test-reporter-robot

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -15,6 +15,7 @@ orgs:
     - google-admin
     - googlebot
     - grantr
+    - knative-automation
     - knative-prow-robot
     - markusthoemmes
     - mattmoor


### PR DESCRIPTION
As per title, adding @knative-automation to knative and knative-sandbox community.

Currently we need to add `/ok-to-test` every auto PR like https://github.com/knative/serving/pull/9943.

/cc @knative/technical-oversight-committee
