### PR TITLE
Push one more 1 week for end of year holidays

### DIFF
--- a/mechanics/RELEASE-SCHEDULE.md
+++ b/mechanics/RELEASE-SCHEDULE.md
@@ -9,8 +9,8 @@ With that said, it can be useful to have a list of when future releases will hap
 | 0.17    | 2020-08-18 |
 | 0.18    | 2020-09-29 |
 | 0.19    | 2020-11-10 |
-| 0.20    | 2021-01-05 ** Moved by 2 weeks for end of year holidays** |
-| 0.21    | 2021-02-16 |
-| 0.22    | 2021-03-30 |
-| 0.23    | 2021-05-11 |
-| 0.24    | 2021-06-22 |
+| 0.20    | 2021-01-12 ** Moved by 3 weeks for end of year holidays** |
+| 0.21    | 2021-02-23 |
+| 0.22    | 2021-04-06 |
+| 0.23    | 2021-05-18 |
+| 0.24    | 2021-06-29 |


### PR DESCRIPTION
As per https://github.com/knative/pkg/pull/1803, v0.2.0 is moved by 3
weeks for end of year holidays so this PR sync with the schedules.

/cc @evankanderson @n3wscott @tcnghia @slinkydeveloper 