### PR TITLE
Add the upcoming releases & k8s min versions

### DIFF
--- a/mechanics/RELEASE-SCHEDULE.md
+++ b/mechanics/RELEASE-SCHEDULE.md
@@ -9,8 +9,8 @@ With that said, it can be useful to have a list of when future releases will hap
 | 0.17    | 2020-08-18 |
 | 0.18    | 2020-09-29 |
 | 0.19    | 2020-11-10 |
-| 0.20    | 2021-01-05 ** Moved by 2 weeks for end of year holidays** |
-| 0.21    | 2021-02-16 |
-| 0.22    | 2021-03-30 |
-| 0.23    | 2021-05-11 |
-| 0.24    | 2021-06-22 |
+| 0.20    | 2021-01-12 ** Moved by 3 weeks for end of year holidays** |
+| 0.21    | 2021-02-23 |
+| 0.22    | 2021-04-06 |
+| 0.23    | 2021-05-18 |
+| 0.24    | 2021-06-29 |

--- a/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
+++ b/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
@@ -526,13 +526,34 @@ tuple
    </td>
   </tr>
   <tr>
-   <td rowspan="2" >0.20.x
+   <td rowspan="2" >0.21.x
    </td>
    <td rowspan="2" >2021-02-23
    </td>
    <td rowspan="2" >2021-08-10
    </td>
    <td rowspan="2" >v1.18x
+   </td>
+   <td rowspan="2" >v1
+   </td>
+   <td rowspan="2" >N/A
+   </td>
+   <td>v1
+   </td>
+   <td>v1
+   </td>
+   <td>default
+   </td>
+  </tr>
+  <tr>
+  <tr>
+   <td rowspan="2" >0.20.x
+   </td>
+   <td rowspan="2" >2021-01-12
+   </td>
+   <td rowspan="2" >2021-06-29
+   </td>
+   <td rowspan="2" >v1.17x
    </td>
    <td rowspan="2" >v1
    </td>

--- a/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
+++ b/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
@@ -526,13 +526,13 @@ tuple
    </td>
   </tr>
   <tr>
-   <td rowspan="2" >0.19.x
+   <td rowspan="2" >0.20.x
    </td>
-   <td rowspan="2" >2020-12-22
+   <td rowspan="2" >2021-02-23
    </td>
-   <td rowspan="2" >2021-06-08
+   <td rowspan="2" >2021-08-10
    </td>
-   <td rowspan="2" >v1.17x
+   <td rowspan="2" >v1.18x
    </td>
    <td rowspan="2" >v1
    </td>
@@ -556,9 +556,9 @@ tuple
   <tr>
    <td rowspan="2" >0.19.x
    </td>
-   <td rowspan="2" >2020-12-22
+   <td rowspan="2" >2020-11-10
    </td>
-   <td rowspan="2" >2021-06-08
+   <td rowspan="2" >2021-05-18
    </td>
    <td rowspan="2" >v1.17x
    </td>

--- a/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
+++ b/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
@@ -526,17 +526,17 @@ tuple
    </td>
   </tr>
   <tr>
-   <td>0.21.x
+   <td rowspan="2" >0.21.x
    </td>
-   <td>2021-02-23
+   <td rowspan="2" >2021-02-23
    </td>
-   <td>2021-08-10
+   <td rowspan="2" >2021-08-10
    </td>
-   <td>v1.18x
+   <td rowspan="2" >v1.18x
    </td>
-   <td>v1
+   <td rowspan="2" >v1
    </td>
-   <td>N/A
+   <td rowspan="2" >N/A
    </td>
    <td>v1
    </td>
@@ -546,6 +546,13 @@ tuple
    </td>
   </tr>
   <tr>
+   <td>v1beta1
+   </td>
+   <td>v1beta1
+   </td>
+   <td><strong>optional (deprecated)</strong>
+   </td>
+  </tr>
   <tr>
    <td rowspan="2" >0.20.x
    </td>
@@ -571,7 +578,7 @@ tuple
    </td>
    <td>v1beta1
    </td>
-   <td><strong>removed</strong>
+   <td><strong>optional (deprecated)</strong>
    </td>
   </tr>
   <tr>
@@ -599,7 +606,7 @@ tuple
    </td>
    <td>v1beta1
    </td>
-   <td><strong>removed</strong>
+   <td><strong>optional (deprecated)</strong>
    </td>
   </tr>
   <tr>
@@ -627,7 +634,7 @@ tuple
    </td>
    <td>v1beta1
    </td>
-   <td><strong>not served</strong>
+   <td><strong>optional (deprecated)</strong>
    </td>
   </tr>
   <tr>

--- a/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
+++ b/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
@@ -550,7 +550,7 @@ tuple
    </td>
    <td>v1beta1
    </td>
-   <td><strong>optional (deprecated)</strong>
+   <td>optional (deprecated)
    </td>
   </tr>
   <tr>
@@ -578,7 +578,7 @@ tuple
    </td>
    <td>v1beta1
    </td>
-   <td><strong>optional (deprecated)</strong>
+   <td>optional (deprecated)
    </td>
   </tr>
   <tr>
@@ -606,7 +606,7 @@ tuple
    </td>
    <td>v1beta1
    </td>
-   <td><strong>optional (deprecated)</strong>
+   <td>optional (deprecated)
    </td>
   </tr>
   <tr>
@@ -634,7 +634,7 @@ tuple
    </td>
    <td>v1beta1
    </td>
-   <td><strong>optional (deprecated)</strong>
+   <td>optional (deprecated)
    </td>
   </tr>
   <tr>

--- a/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
+++ b/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
@@ -526,17 +526,17 @@ tuple
    </td>
   </tr>
   <tr>
-   <td rowspan="2" >0.21.x
+   <td>0.21.x
    </td>
-   <td rowspan="2" >2021-02-23
+   <td>2021-02-23
    </td>
-   <td rowspan="2" >2021-08-10
+   <td>2021-08-10
    </td>
-   <td rowspan="2" >v1.18x
+   <td>v1.18x
    </td>
-   <td rowspan="2" >v1
+   <td>v1
    </td>
-   <td rowspan="2" >N/A
+   <td>N/A
    </td>
    <td>v1
    </td>

--- a/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
+++ b/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
@@ -219,8 +219,6 @@ tuple
    </td>
    <td><strong>Storage Type</strong>
    </td>
-   <td><strong>Force Upgrade</strong>
-   </td>
    <td><strong>API Endpoints</strong>
    </td>
    <td><strong>API Type Served</strong>
@@ -228,18 +226,16 @@ tuple
    <td><strong>Availability</strong>
    </td>
   </tr>
-  <tr>
-   <td rowspan="3" >0.20.x
+    <tr>
+   <td>0.21.x
    </td>
-   <td rowspan="3" >2020-12-22
+   <td>2021-02-23
    </td>
-   <td rowspan="3" >2021-06-08
+   <td>2021-08-10
    </td>
-   <td rowspan="3" >(undetermined)
+   <td>v1.18.x
    </td>
-   <td rowspan="3" >v1
-   </td>
-   <td rowspan="3" >N/A
+   <td>v1
    </td>
    <td>v1
    </td>
@@ -249,19 +245,21 @@ tuple
    </td>
   </tr>
   <tr>
-   <td>v1beta1
+   <td>0.20.x
    </td>
-   <td>v1beta1
+   <td>2021-01-12
    </td>
-   <td><strong>removed</strong>
+   <td>2021-06-29
    </td>
-  </tr>
-  <tr>
-   <td>v1alpha1
+   <td>v1.17.x
    </td>
-   <td>Lemonade
+   <td>v1
    </td>
-   <td><strong>removed</strong>
+   <td>v1
+   </td>
+   <td>v1
+   </td>
+   <td>default
    </td>
   </tr>
   <tr>
@@ -269,13 +267,11 @@ tuple
    </td>
    <td rowspan="3" >2020-11-10
    </td>
-   <td rowspan="3" >2021-04-27
+   <td rowspan="3" >2021-05-18
    </td>
-   <td rowspan="3" >(undetermined)
+   <td rowspan="3" >v1.17.x
    </td>
    <td rowspan="3" >v1
-   </td>
-   <td rowspan="3" >N/A
    </td>
    <td>v1
    </td>
@@ -311,8 +307,6 @@ tuple
    </td>
    <td rowspan="3" >v1
    </td>
-   <td rowspan="3" >N/A
-   </td>
    <td>v1
    </td>
    <td>v1
@@ -346,8 +340,6 @@ tuple
    <td rowspan="3" >1.16.x
    </td>
    <td rowspan="3" >v1
-   </td>
-   <td rowspan="3" >N/A
    </td>
    <td>v1
    </td>
@@ -383,8 +375,6 @@ tuple
    </td>
    <td rowspan="3" >v1
    </td>
-   <td rowspan="3" >N/A
-   </td>
    <td>v1
    </td>
    <td>v1
@@ -418,8 +408,6 @@ tuple
    <td rowspan="3" >1.16.x
    </td>
    <td rowspan="3" >v1
-   </td>
-   <td rowspan="3" >N/A
    </td>
    <td>v1
    </td>
@@ -455,8 +443,6 @@ tuple
    </td>
    <td rowspan="3" >v1
    </td>
-   <td rowspan="3" >N/A
-   </td>
    <td>v1
    </td>
    <td>v1
@@ -491,8 +477,6 @@ tuple
    </td>
    <td rowspan="3" >v1alpha1
    </td>
-   <td rowspan="3" >N/A
-   </td>
    <td>v1
    </td>
    <td>v1
@@ -514,336 +498,6 @@ tuple
    <td>Lemonade
    </td>
    <td>default (deprecated)
-   </td>
-  </tr>
-  <tr>
-   <td rowspan="3" >0.12.x
-   </td>
-   <td rowspan="3" >2020-01-21
-   </td>
-   <td rowspan="3" >2020-07-07
-   </td>
-   <td rowspan="3" >1.15.x
-   </td>
-   <td rowspan="3" >v1alpha1
-   </td>
-   <td rowspan="3" >N/A
-   </td>
-   <td>v1
-   </td>
-   <td>v1
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td>v1beta1
-   </td>
-   <td>v1beta1
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td>v1alpha1
-   </td>
-   <td>Lemonade
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td rowspan="3" >0.11.x
-   </td>
-   <td rowspan="3" >2019-12-10
-   </td>
-   <td rowspan="3" >2020-05-26
-   </td>
-   <td rowspan="3" >1.14.x
-   </td>
-   <td rowspan="3" >v1alpha1 (Lemonade)
-   </td>
-   <td rowspan="3" >Yes
-   </td>
-   <td>v1
-   </td>
-   <td>v1
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td>v1beta1
-   </td>
-   <td>v1beta1
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td>v1alpha1
-   </td>
-   <td>Lemonade
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td rowspan="3" >0.10.x
-   </td>
-   <td rowspan="3" >2019-10-29
-   </td>
-   <td rowspan="3" >2020-04-14
-   </td>
-   <td rowspan="3" >1.14.x
-   </td>
-   <td rowspan="3" >v1alpha1 (Lemonade)
-   </td>
-   <td rowspan="3" >Yes
-   </td>
-   <td>v1
-   </td>
-   <td>v1
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td>v1beta1
-   </td>
-   <td>v1beta1
-   </td>
-   <td>default (deprecated)
-   </td>
-  </tr>
-  <tr>
-   <td>v1alpha1
-   </td>
-   <td>Lemonade
-   </td>
-   <td>default 
-<p>
-(deprecated)
-   </td>
-  </tr>
-  <tr>
-   <td rowspan="3" >0.9.x
-   </td>
-   <td rowspan="3" >2019-09-17
-   </td>
-   <td rowspan="3" >2020-03-03
-   </td>
-   <td>1.13.10
-   </td>
-   <td rowspan="3" >v1alpha1 (Lemonade)
-   </td>
-   <td rowspan="3" >Yes
-   </td>
-   <td>v1
-   </td>
-   <td>v1
-   </td>
-   <td>optional
-   </td>
-  </tr>
-  <tr>
-   <td>1.13.10
-   </td>
-   <td>v1beta1
-   </td>
-   <td>v1beta1
-   </td>
-   <td>optional
-   </td>
-  </tr>
-  <tr>
-   <td>1.11
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>Lemonade
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td rowspan="2" >0.8.x
-   </td>
-   <td rowspan="2" >2019-08-06
-   </td>
-   <td rowspan="2" >2020-01-21
-   </td>
-   <td>1.13.10
-   </td>
-   <td rowspan="2" >v1alpha1 (Lemonade)
-   </td>
-   <td rowspan="2" >Yes
-   </td>
-   <td>v1beta1
-   </td>
-   <td>v1beta1
-   </td>
-   <td>optional
-   </td>
-  </tr>
-  <tr>
-   <td>1.11
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>Lemonade
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td rowspan="2" >0.7.x
-   </td>
-   <td rowspan="2" >2019-06-25
-   </td>
-   <td rowspan="2" >2019-12-10
-   </td>
-   <td>1.13.10
-   </td>
-   <td rowspan="2" >v1alpha1 (Lemonade)
-   </td>
-   <td rowspan="2" >Yes
-   </td>
-   <td>v1beta1
-   </td>
-   <td>v1beta1
-   </td>
-   <td>optional
-   </td>
-  </tr>
-  <tr>
-   <td>1.11
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>Lemonade
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td>0.6.x
-   </td>
-   <td>2019-05-14
-   </td>
-   <td>2019-10-29
-   </td>
-   <td>1.11
-   </td>
-   <td>v1alpha1 (Lemonade)
-   </td>
-   <td>No
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>Lemonade
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td>0.5.x
-   </td>
-   <td>2019-04-02
-   </td>
-   <td>2019-09-17
-   </td>
-   <td>1.11
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>N/A
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td>0.4.x
-   </td>
-   <td>2019-02-19
-   </td>
-   <td>2019-08-06
-   </td>
-   <td>1.11
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>N/A
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td>0.3.x
-   </td>
-   <td>2019-01-08
-   </td>
-   <td>2019-06-25
-   </td>
-   <td>1.11
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>N/A
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td>0.2.x
-   </td>
-   <td>2018-10-30
-   </td>
-   <td>2019-05-14
-   </td>
-   <td>1.09
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>N/A
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>default
-   </td>
-  </tr>
-  <tr>
-   <td>0.1.x
-   </td>
-   <td>2018-07-18
-   </td>
-   <td>2019-04-02
-   </td>
-   <td>1.09
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>N/A
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>v1alpha1
-   </td>
-   <td>default
    </td>
   </tr>
 </table>
@@ -878,7 +532,35 @@ tuple
    </td>
    <td rowspan="2" >2021-06-08
    </td>
-   <td rowspan="2" >(undetermined)
+   <td rowspan="2" >v1.17x
+   </td>
+   <td rowspan="2" >v1
+   </td>
+   <td rowspan="2" >N/A
+   </td>
+   <td>v1
+   </td>
+   <td>v1
+   </td>
+   <td>default
+   </td>
+  </tr>
+  <tr>
+   <td>v1beta1
+   </td>
+   <td>v1beta1
+   </td>
+   <td><strong>removed</strong>
+   </td>
+  </tr>
+  <tr>
+   <td rowspan="2" >0.19.x
+   </td>
+   <td rowspan="2" >2020-12-22
+   </td>
+   <td rowspan="2" >2021-06-08
+   </td>
+   <td rowspan="2" >v1.17x
    </td>
    <td rowspan="2" >v1
    </td>


### PR DESCRIPTION
Related: https://github.com/knative/community/issues/245

Fixes 
- https://github.com/knative/docs/issues/2796 
- https://github.com/knative/docs/issues/2797

See the [rendered](https://github.com/knative/community/blob/c627bdfdb506a4e12f13db52cc006ec88b1ec242/mechanics/RELEASE-VERSIONING-PRINCIPLES.md) preview. I dropped older releases.

Based on the current principles we're going to make v1.17 our min K8s for the Knative release 0.20.x - but it will EOL 2-3 weeks later. 