### PR TITLE
Add mohamedelhawaty to knative member list

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -317,6 +317,7 @@ orgs:
     - minsungh
     - mkocher
     - mogar1980
+    - mohamedelhawaty
     - monikanawrot
     - MontyCarter
     - mpetason


### PR DESCRIPTION
Mohamed Elhawaty is a new member in the Knative Eventing team at Google