### PR TITLE
Remove my old github username from the voters file

### DIFF
--- a/elections/2020/SC/voters.md
+++ b/elections/2020/SC/voters.md
@@ -20,7 +20,6 @@ The eligible voter process can be found in the [SC election mechanics](../../mec
 ## GitHub IDs
 
 - aavarghese
-- Abd4llA
 - abrennan89
 - AceHack
 - adrcunha


### PR DESCRIPTION
I've renamed my github username from Abd4llA to devguyio . This is a proof https://github.com/cncf/gitdm/pull/398