### PR TITLE
Add chizhg to Knative Milestone Maintainers

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -804,6 +804,7 @@ orgs:
         - andrew-su
         - aslom
         - chaodaiG
+        - chizhg
         - csantanapr
         - devguyio
         - eallred-google


### PR DESCRIPTION
Add `chizhg` to Knative Milestone Maintainers to be able to trigger Prow jobs from UI