### PR TITLE
Update Release Leads for 0.20

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -565,8 +565,8 @@ orgs:
           Knative Release Leads:
             description: Active member of the Knative Release Leads rotation.
             maintainers:
-            - julz
-            - n3wscott
+            - nak3
+            - slinkydeveloper
       Knative Milestone Maintainers:
         description: 'DO NOT RENAME - this group is used by Prow to control who can
           manipulate milestones: https://github.com/knative/test-infra/blob/64615f92c4ebdd4e4423015ffc0db45877660a0d/ci/prow/plugins.yaml#L49'

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -787,8 +787,8 @@ orgs:
           Knative Release Leads:
             description: Active member of the Knative Release Leads rotation.
             maintainers:
-            - julz
-            - n3wscott
+            - nak3
+            - slinkydeveloper
       Knative Milestone Maintainers:
         description: 'DO NOT RENAME - this group is used by Prow to control who can manipulate
           milestones: https://github.com/knative/test-infra/blob/64615f92c4ebdd4e4423015ffc0db45877660a0d/ci/prow/plugins.yaml#L49'


### PR DESCRIPTION
Following the [Release Leads process](https://github.com/knative/pkg/blob/master/RELEASE-LEADS.md): the release is now cut, passing on the torch to @nak3 and @slinkydeveloper!.

/assign @n3wscott @mattmoor 