### PR TITLE
Add self to knative-sandbox team members

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -42,6 +42,7 @@ orgs:
     - anishj0shi
     - antoineco
     - arghya88
+    - arturenault
     - aslakknutsen
     - aslom
     - balopat


### PR DESCRIPTION
I'm a Google engineer working on knative - I've added myself to knative but not knative-sandbox and it's been causing issues in the net-istio repo.