### PR TITLE
Allow TOC to manage .github directory

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- technical-oversight-committee
+
+reviewers:
+- technical-oversight-committee


### PR DESCRIPTION
# Changes

Allow and assign `.github` reviews to TOC, rather than to Steering. Since OWNERS is hierarchical, Steering will still have ability to approve PRs, but they won't be blocked.

/kind cleanup

See discussion in #390 

/assign @bsnchan 