### PR TITLE
Add Haolicopter to knative and knative sandbox members

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -101,6 +101,7 @@ orgs:
     - gyliu513
     - gyohuangxin
     - halvards
+    - Haolicopter
     - Harwayne
     - hev
     - houshengbo

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -202,6 +202,7 @@ orgs:
     - gsiener
     - gyliu513
     - halvards
+    - Haolicopter
     - hardl
     - Harwayne
     - hatofmonkeys


### PR DESCRIPTION
I'm working on Knative eventing at Google.

* Update knative-sandbox.yaml: Add Haolicopter

Add to the members list

* Update knative.yaml: Add Haolicopter

Add to members list