### PR TITLE
Add a Golang policy

### DIFF
--- a/mechanics/GOLANG-POLICY.md
+++ b/mechanics/GOLANG-POLICY.md
@@ -1,0 +1,32 @@
+---
+title: "Knative Golang policy"
+linkTitle: "Golang policy"
+weight: 50
+type: "docs"
+---
+
+Knative's components are mostly written in Golang. As such the project has to deal with
+major and minor upgrades of the Go language itself. The following principles are applied
+regarding the Golang version Knative tests and releases with.
+
+## Recency
+
+Knative generally strives to always use the most recent Golang version available, to
+ensure future compatibility and top benefit from the ongoing optimization to the Golang
+runtime.
+
+CI systems (Prow and Github Actions) should try to always be on the most recent patch
+level.
+
+## Consistency
+
+All repositories should depend on the same Golang version, evidenced in their respective
+`go.mod` file.
+
+## Caution
+
+Major Golang version bumps (i.e. 1.14 to 1.15) should be made deliberately and should not
+be taken too lightly. Such a change should not happen closely to a release cycle of
+Knative. If the bump would be within two weeks of the Knative release cycle, it should be
+postponed until the next release to allow for thorough testing and hardening. Exceptions
+to this should be discussed and agreed upon through the TOC.

--- a/mechanics/GOLANG-POLICY.md
+++ b/mechanics/GOLANG-POLICY.md
@@ -30,3 +30,6 @@ be taken too lightly. Such a change should not happen closely to a release cycle
 Knative. If the bump would be within two weeks of the Knative release cycle, it should be
 postponed until the next release to allow for thorough testing and hardening. Exceptions
 to this should be discussed and agreed upon through the TOC.
+
+Since such a version bump can potentially be breaking to some repositories, the change
+should be widely announced and agreed upon.

--- a/mechanics/GOLANG-POLICY.md
+++ b/mechanics/GOLANG-POLICY.md
@@ -12,7 +12,7 @@ regarding the Golang version Knative tests and releases with.
 ## Recency
 
 Knative generally strives to always use the most recent Golang version available, to
-ensure future compatibility and top benefit from the ongoing optimization to the Golang
+ensure future compatibility and to benefit from the ongoing optimization to the Golang
 runtime.
 
 CI systems (Prow and Github Actions) should try to always be on the most recent patch
@@ -26,10 +26,10 @@ All repositories should depend on the same Golang version, evidenced in their re
 ## Caution
 
 Major Golang version bumps (i.e. 1.14 to 1.15) should be made deliberately and should not
-be taken too lightly. Such a change should not happen closely to a release cycle of
+be taken too lightly. Such a change should not happen too closely to a release of
 Knative. If the bump would be within two weeks of the Knative release cycle, it should be
 postponed until the next release to allow for thorough testing and hardening. Exceptions
 to this should be discussed and agreed upon through the TOC.
 
 Since such a version bump can potentially be breaking to some repositories, the change
-should be widely announced and agreed upon.
+should be announced and discussed and agreed upon between the impacted working groups.


### PR DESCRIPTION
Fixes #355 

As promised in the TOC meeting, here's my stab at a Golang "policy". I hope it captures what was discussed in the meeting.

TOC is kept out of any approval paths except for "emergency" updates shortly before a release. We've never had such a case yet, but it felt right to have a handle at that specific edge-case. I wanted to put "should be widely discussed and agreed upon", which kinda felt equal to "bring it to the TOC meeting".

/assign @evankanderson @mattmoor @tcnghia @grantr 