### PR TITLE
Update Eventing WG to new Knative Drive links

### DIFF
--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -136,10 +136,10 @@ Event sources, bindings, FaaS framework, and orchestration
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Charter / Mission          | [Enable asynchronous application development through event delivery from anywhere.](https://github.com/knative/eventing/blob/master/docs/mission.md)       |
 | Forum                      | [knative-dev@](https://groups.google.com/forum/#!forum/knative-dev)                                                                                        |
-| Community Meeting VC       | See the top of the [Meeting notes](https://docs.google.com/document/d/1uGDehQu493N_XCAT5H4XEw5T9IWlPN1o19ULOWKuPnY/edit)                                   |
+| Community Meeting VC       | See the top of the [Meeting notes](https://docs.google.com/document/d/1Xha-FeunojN49OJN7W0WBnPMcRtp1ycYpbkiir6XsE0/edit)                                   |
 | Community Meeting Calendar | Wednesdays 9:00a-9:30a PST<br>[Calendar](https://calendar.google.com/calendar/embed?src=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com) |
-| Meeting Notes              | [Notes](https://docs.google.com/document/d/1uGDehQu493N_XCAT5H4XEw5T9IWlPN1o19ULOWKuPnY/edit)                                                              |
-| Document Folder            | [Folder](https://drive.google.com/corp/drive/folders/1S22YmGl6B1ppYApwa1j5j9Nc6rEChlPo)                                                                    |
+| Meeting Notes              | [Notes](https://docs.google.com/document/d/1Xha-FeunojN49OJN7W0WBnPMcRtp1ycYpbkiir6XsE0/edit)                                                              |
+| Document Folder            | [Folder](https://drive.google.com/corp/drive/u/0/folders/16A4v6Qv9MNSumpy6geGm0u1izDqAfiNo)                                                                    |
 | Repo prefixes              | `eventing-*`                                                                                                                                               |
 | Slack Channel              | [#eventing](https://slack.knative.dev/messages/eventing)                                                                                                   |
 


### PR DESCRIPTION
Updating the Eventing WG links to use the new doc and folder that @tcnghia set up.

/cc @tcnghia