### PR TITLE
Remove duplicatd user in admin and member role

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -221,7 +221,6 @@ orgs:
     - tzununbekov
     - uwefassnacht
     - vagababov
-    - vaikas
     - vbatts
     - vdemeester
     - wfernandes

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -467,7 +467,6 @@ orgs:
     - univ0298
     - uwefassnacht
     - vagababov
-    - vaikas
     - vaikas-personal
     - vantuvt
     - vasu1124


### PR DESCRIPTION
2d0783b7a1d9b1f4bdd141db70023d9f5dbefdb2 added vaikas as an admin. It
causes peribolos configuration [error](https://prow.knative.dev/view/gcs/knative-prow/logs/post-knative-sandbox-peribolos/1339745466102845440):

```
{"component":"unset","file":"prow/cmd/peribolos/main.go:202","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure knative-sandbox members: users in both roles: vaikas","severity":"fatal","time":"2020-12-18T01:33:12Z"}
```

To fix it, this patch removes vaikas from member list but keeps vaikas in admin list.

# Changes

/kind bug

**Release Note**

```release-note
NONE
```

/cc @evankanderson @bsnchan @vaikas 
