### PR TITLE
add nlopezgi to Knative Milestone Maintainers

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -814,6 +814,7 @@ orgs:
         - julz
         - nak3
         - navidshaikh
+        - nlopezgi
         - rhuss
         - shashwathi
         - sixolet


### PR DESCRIPTION
To allow me to kick off knative-gcp release job

<!-- Thanks for sending a pull request! -->

# Changes

- add nlopezgi to Knative Milestone Maintainers

/kind documentation

Allow nlopezgi to manually kick off release prow job for knative-gcp repo

