### PR TITLE
chore: Add kn-plugin-migration to peribolos configuration

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -362,6 +362,18 @@ orgs:
         description: Kn plugin for managing a Kubernetes based Knative installation.
         has_projects: true
         has_wiki: false
+      kn-plugin-diag:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        description: Kn plugin for exposing detailed information for different layer of knative objects for diagnose.
+        has_projects: true
+        has_wiki: false
+      kn-plugin-migration:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        description: Kn plugin for migrating Knative services from one cluster to another.
+        has_projects: true
+        has_wiki: false
       kn-plugin-source-kafka:
         allow_merge_commit: false
         allow_rebase_merge: false
@@ -380,12 +392,6 @@ orgs:
         description: Common code for Kn source plugins
         has_projects: true
         has_wiki: false
-      kn-plugin-diag:
-        allow_merge_commit: false
-        allow_rebase_merge: false
-        description: Kn plugin for exposing detailed information for different layer of knative objects for diagnose.
-        has_projects: true
-        has_wiki: false        
       knobots:
         allow_merge_commit: false
         allow_rebase_merge: false
@@ -466,10 +472,11 @@ orgs:
         repos:
           build-spike: write
           kn-plugin-admin: write
+          kn-plugin-diag: write
+          kn-plugin-migration: write
           kn-plugin-source-kafka: write
           kn-plugin-source-kamelet: write
           kn-plugin-source-pkg: write
-          kn-plugin-diag: write
         teams:
           Client WG Leads:
             description: The Working Group Leads for Client
@@ -554,10 +561,11 @@ orgs:
           eventing-rabbitmq: admin
           eventing-redis: admin
           kn-plugin-admin: admin
+          kn-plugin-diag: admin
+          kn-plugin-migration: admin
           kn-plugin-source-kafka: admin
           kn-plugin-source-kamelet: admin
           kn-plugin-source-pkg: admin
-          kn-plugin-diag: admin
           knobots: admin
           kperf: admin
           net-certmanager: admin


### PR DESCRIPTION
and sorting the kn plugins in alphabetical order.