### PR TITLE
Add icons for Serving and Eventing

### DIFF
--- a/icons/broker.svg
+++ b/icons/broker.svg
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="50mm"
+   height="50mm"
+   viewBox="0 0 50 50"
+   version="1.1"
+   id="svg855"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="broker.svg">
+  <defs
+     id="defs849" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.196421"
+     inkscape:cx="93.283938"
+     inkscape:cy="85.72063"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1513"
+     inkscape:window-height="1048"
+     inkscape:window-x="2275"
+     inkscape:window-y="185"
+     inkscape:window-maximized="0"
+     units="mm"
+     inkscape:pagecheckerboard="true"
+     inkscape:snap-text-baseline="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2210" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata852">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:none">
+    <rect
+       style="display:inline;opacity:1;fill:#3d8037;fill-opacity:0.400538;stroke-width:0.2732;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212"
+       width="75"
+       height="75"
+       x="0.059107598"
+       y="0.091476537"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#3d5238;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9"
+       width="75"
+       height="75"
+       x="75.059105"
+       y="0.091476537"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#905238;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9-3"
+       width="75"
+       height="75"
+       x="75.059105"
+       y="75.091476"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#9052ac;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9-3-6"
+       width="75"
+       height="75"
+       x="0.059107598"
+       y="75.091476"
+       ry="5.9678059e-14" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline">
+    <ellipse
+       style="opacity:1;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6915"
+       cx="24.969109"
+       cy="-46.731319"
+       rx="3.2488241"
+       ry="3.2362084"
+       transform="rotate(90)" />
+    <ellipse
+       style="display:inline;opacity:1;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6915-3"
+       cx="-0.046494029"
+       cy="-57.054607"
+       rx="3.2488241"
+       ry="3.2362084"
+       transform="rotate(135)" />
+    <ellipse
+       style="display:inline;opacity:1;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6915-8"
+       cx="-25.034863"
+       cy="-46.665569"
+       rx="3.2488241"
+       ry="3.2362084"
+       transform="scale(-1)" />
+    <ellipse
+       style="display:inline;opacity:1;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6915-6"
+       cx="-35.358147"
+       cy="-21.649963"
+       rx="3.2488241"
+       ry="3.2362084"
+       transform="rotate(-135)" />
+    <ellipse
+       style="display:inline;opacity:1;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6915-2"
+       cx="-24.969107"
+       cy="3.338403"
+       rx="3.2488241"
+       ry="3.2362084"
+       transform="rotate(-90)" />
+    <ellipse
+       style="display:inline;opacity:1;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6915-67"
+       cx="0.046500914"
+       cy="13.661688"
+       rx="3.2488241"
+       ry="3.2362084"
+       transform="rotate(-44.999991)" />
+    <ellipse
+       style="display:inline;opacity:1;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6915-5"
+       cx="25.034863"
+       cy="3.272649"
+       rx="3.2488241"
+       ry="3.2362084" />
+    <ellipse
+       style="display:inline;opacity:1;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path6915-69"
+       cx="35.358147"
+       cy="-21.742971"
+       rx="3.2488241"
+       ry="3.2362084"
+       transform="rotate(45.000022)" />
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-8"
+       width="1.8101028"
+       height="4.6363201"
+       x="24.094948"
+       y="-42.818161"
+       ry="8.0192963e-15"
+       transform="rotate(90)" />
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-8-7"
+       width="1.8101028"
+       height="4.6363201"
+       x="-0.90505248"
+       y="-53.1735"
+       ry="8.0192963e-15"
+       transform="rotate(135)" />
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-8-2"
+       width="1.8101028"
+       height="4.6363201"
+       x="-25.905052"
+       y="-42.818161"
+       ry="8.0192963e-15"
+       transform="scale(-1)" />
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-8-8"
+       width="1.8101028"
+       height="4.6363201"
+       x="-36.260391"
+       y="-17.818161"
+       ry="8.0192963e-15"
+       transform="rotate(-135)" />
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-8-29"
+       width="1.8101028"
+       height="4.6363201"
+       x="-25.905048"
+       y="7.1818399"
+       ry="8.0192963e-15"
+       transform="rotate(-90)" />
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-8-9"
+       width="1.8101028"
+       height="4.6363201"
+       x="-0.90504539"
+       y="17.53718"
+       ry="8.0192963e-15"
+       transform="rotate(-44.999991)" />
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-8-6"
+       width="1.8101028"
+       height="4.6363201"
+       x="24.094948"
+       y="7.1818409"
+       ry="8.0192963e-15" />
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-8-0"
+       width="1.8101028"
+       height="4.6363201"
+       x="34.450287"
+       y="-17.818176"
+       ry="8.0192963e-15"
+       transform="rotate(45.000025)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:35.829px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#2592b0;fill-opacity:1;stroke:none;stroke-width:0.895727"
+       x="13.857169"
+       y="34.548439"
+       id="text7472"><tspan
+         sodipodi:role="line"
+         id="tspan7470"
+         x="13.857169"
+         y="34.548439"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:35.829px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#2592b0;fill-opacity:1;stroke-width:0.895727">e</tspan></text>
+  </g>
+</svg>

--- a/icons/channel.svg
+++ b/icons/channel.svg
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="50mm"
+   height="50mm"
+   viewBox="0 0 50 50"
+   version="1.1"
+   id="svg855"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="channel.svg">
+  <defs
+     id="defs849" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.196421"
+     inkscape:cx="99.20946"
+     inkscape:cy="135.78865"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1743"
+     inkscape:window-height="1150"
+     inkscape:window-x="1953"
+     inkscape:window-y="132"
+     inkscape:window-maximized="0"
+     units="mm"
+     inkscape:pagecheckerboard="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2210" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata852">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:none">
+    <rect
+       style="display:inline;opacity:1;fill:#3d8037;fill-opacity:0.400538;stroke-width:0.2732;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212"
+       width="75"
+       height="75"
+       x="0.059107598"
+       y="0.091476537"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#3d5238;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9"
+       width="75"
+       height="75"
+       x="75.059105"
+       y="0.091476537"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#905238;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9-3"
+       width="75"
+       height="75"
+       x="75.059105"
+       y="75.091476"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#9052ac;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9-3-6"
+       width="75"
+       height="75"
+       x="0.059107598"
+       y="75.091476"
+       ry="5.9678059e-14" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:33.3555px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#2592b0;fill-opacity:1;stroke:none;stroke-width:0.833888"
+       x="9.2892561"
+       y="33.889244"
+       id="text7472"><tspan
+         sodipodi:role="line"
+         id="tspan7470"
+         x="9.2892561"
+         y="33.889244"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:33.3555px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#2592b0;fill-opacity:1;stroke-width:0.833888">e</tspan></text>
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-8-9"
+       width="2.4225321"
+       height="6.2049708"
+       x="23.788734"
+       y="-6.2049713"
+       ry="1.0732543e-14"
+       transform="rotate(90)" />
+    <g
+       id="g14368"
+       transform="translate(0.19042203,-0.38300552)">
+      <g
+         id="g14357"
+         transform="translate(0,0.32321547)">
+        <ellipse
+           style="fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path6915"
+           cx="25.05979"
+           cy="-45.478432"
+           rx="4.3480296"
+           ry="4.3311458"
+           transform="rotate(90)" />
+        <rect
+           style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect6836-1-8"
+           width="2.4225321"
+           height="6.2049708"
+           x="23.889864"
+           y="-40.241295"
+           ry="1.0732543e-14"
+           transform="rotate(90)" />
+      </g>
+      <g
+         id="g13703"
+         transform="translate(1.1374415)">
+        <ellipse
+           style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path6915-3"
+           cx="14.341574"
+           cy="-57.883663"
+           rx="4.3480296"
+           ry="4.3311458"
+           transform="rotate(120.81993)" />
+        <rect
+           style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect6836-1-8-7"
+           width="2.4225321"
+           height="6.2049708"
+           x="13.192532"
+           y="-52.689426"
+           ry="1.0732543e-14"
+           transform="rotate(120.81993)" />
+      </g>
+      <g
+         id="g13699">
+        <ellipse
+           style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path6915-3-9"
+           cx="-29.838108"
+           cy="-32.850937"
+           rx="4.3480296"
+           ry="4.3311458"
+           transform="matrix(-0.51234162,-0.85878173,-0.85878173,0.51234162,0,0)" />
+        <rect
+           style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect6836-1-8-7-7"
+           width="2.4225321"
+           height="6.2049708"
+           x="-30.987148"
+           y="-27.6567"
+           ry="1.0732543e-14"
+           transform="matrix(-0.51234162,-0.85878173,-0.85878173,0.51234162,0,0)" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/icons/kn-broker-name.svg
+++ b/icons/kn-broker-name.svg
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-broker-name.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.7067607"
+     inkscape:cy="7.5319612"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1530"
+     inkscape:window-height="1141"
+     inkscape:window-x="2853"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke-width:0.01216322;stroke-miterlimit:4;stroke-dasharray:none;stroke:none;stroke-opacity:1"
+       id="path821"
+       sodipodi:sides="7"
+       sodipodi:cx="1.8428989"
+       sodipodi:cy="294.96329"
+       sodipodi:r1="1.769226"
+       sodipodi:r2="1.5940177"
+       sodipodi:arg1="1.1246908"
+       sodipodi:arg2="1.5734898"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 2.6062411,296.55937 -1.5352712,-0.004 -0.95399294,-1.2029 0.34566145,-1.49586 1.38502569,-0.6624 1.3814374,0.66985 0.3375985,1.4977 z"
+       inkscape:transform-center-x="0.0010604645"
+       inkscape:transform-center-y="-0.086589138" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g15653"
+       transform="matrix(0.79763377,0,0,0.79763377,0.49284803,59.561771)"
+       style="fill:#ffffff">
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915"
+         cx="295.02454"
+         cy="-3.5036981"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="rotate(90)" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-3"
+         cx="207.17435"
+         cy="-211.52129"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="rotate(135)" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-8"
+         cx="-2.0357955"
+         cy="-296.49246"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="scale(-1)" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-6"
+         cx="-210.05339"
+         cy="-208.64224"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="rotate(-135)" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-2"
+         cx="-295.02454"
+         cy="0.56789136"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="rotate(-90)" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-67"
+         cx="-207.1743"
+         cy="208.58553"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="rotate(-44.99999)" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-5"
+         cx="2.0357955"
+         cy="293.55664"
+         rx="0.21980365"
+         ry="0.21895014" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-69"
+         cx="210.05347"
+         cy="205.70636"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="rotate(45.000023)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8"
+         width="0.12246498"
+         height="0.31367663"
+         x="294.96542"
+         y="-3.2389488"
+         ry="5.4255653e-16"
+         transform="rotate(90)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-7"
+         width="0.12246498"
+         height="0.31367663"
+         x="207.11627"
+         y="-211.2587"
+         ry="5.4255653e-16"
+         transform="rotate(135)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-2"
+         width="0.12246498"
+         height="0.31367663"
+         x="-2.0946679"
+         y="-296.23215"
+         ry="5.4255653e-16"
+         transform="scale(-1)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-8"
+         width="0.12246498"
+         height="0.31367663"
+         x="-210.11443"
+         y="-208.383"
+         ry="5.4255653e-16"
+         transform="rotate(-135)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-29"
+         width="0.12246498"
+         height="0.31367663"
+         x="-295.08786"
+         y="0.82792366"
+         ry="5.4255653e-16"
+         transform="rotate(-90)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-9"
+         width="0.12246498"
+         height="0.31367663"
+         x="-207.23868"
+         y="208.84772"
+         ry="5.4255642e-16"
+         transform="rotate(-44.99999)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-6"
+         width="0.12246498"
+         height="0.31367663"
+         x="1.9722033"
+         y="293.82111"
+         ry="5.4255653e-16" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-0"
+         width="0.12246498"
+         height="0.31367663"
+         x="209.99203"
+         y="205.97189"
+         ry="5.4255642e-16"
+         transform="rotate(45.000025)" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:2.42406px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0606015"
+         x="1.2795526"
+         y="295.67264"
+         id="text7472"><tspan
+           sodipodi:role="line"
+           id="tspan7470"
+           x="1.2795526"
+           y="295.67264"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:2.42406px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.0606015">e</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:0.348544px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.00871363"
+       x="1.3812865"
+       y="296.69241"
+       id="text17672"><tspan
+         sodipodi:role="line"
+         id="tspan17670"
+         x="1.3812865"
+         y="296.69241"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.00871363">BROKER</tspan></text>
+  </g>
+</svg>

--- a/icons/kn-broker.svg
+++ b/icons/kn-broker.svg
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-broker.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.7067607"
+     inkscape:cy="7.5319612"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1692"
+     inkscape:window-height="1141"
+     inkscape:window-x="2691"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke-width:0.01216322;stroke-miterlimit:4;stroke-dasharray:none;stroke:none;stroke-opacity:1"
+       id="path821"
+       sodipodi:sides="7"
+       sodipodi:cx="1.8428989"
+       sodipodi:cy="294.96329"
+       sodipodi:r1="1.769226"
+       sodipodi:r2="1.5940177"
+       sodipodi:arg1="1.1246908"
+       sodipodi:arg2="1.5734898"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 2.6062411,296.55937 -1.5352712,-0.004 -0.95399294,-1.2029 0.34566145,-1.49586 1.38502569,-0.6624 1.3814374,0.66985 0.3375985,1.4977 z"
+       inkscape:transform-center-x="0.0010604645"
+       inkscape:transform-center-y="-0.086589138" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g15653"
+       transform="matrix(0.79763377,0,0,0.79763377,0.49284803,59.561771)"
+       style="fill:#ffffff">
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915"
+         cx="295.02454"
+         cy="-3.5036981"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="rotate(90)" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-3"
+         cx="207.17435"
+         cy="-211.52129"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="rotate(135)" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-8"
+         cx="-2.0357955"
+         cy="-296.49246"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="scale(-1)" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-6"
+         cx="-210.05339"
+         cy="-208.64224"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="rotate(-135)" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-2"
+         cx="-295.02454"
+         cy="0.56789136"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="rotate(-90)" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-67"
+         cx="-207.1743"
+         cy="208.58553"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="rotate(-44.99999)" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-5"
+         cx="2.0357955"
+         cy="293.55664"
+         rx="0.21980365"
+         ry="0.21895014" />
+      <ellipse
+         style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path6915-69"
+         cx="210.05347"
+         cy="205.70636"
+         rx="0.21980365"
+         ry="0.21895014"
+         transform="rotate(45.000023)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8"
+         width="0.12246498"
+         height="0.31367663"
+         x="294.96542"
+         y="-3.2389488"
+         ry="5.4255653e-16"
+         transform="rotate(90)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-7"
+         width="0.12246498"
+         height="0.31367663"
+         x="207.11627"
+         y="-211.2587"
+         ry="5.4255653e-16"
+         transform="rotate(135)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-2"
+         width="0.12246498"
+         height="0.31367663"
+         x="-2.0946679"
+         y="-296.23215"
+         ry="5.4255653e-16"
+         transform="scale(-1)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-8"
+         width="0.12246498"
+         height="0.31367663"
+         x="-210.11443"
+         y="-208.383"
+         ry="5.4255653e-16"
+         transform="rotate(-135)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-29"
+         width="0.12246498"
+         height="0.31367663"
+         x="-295.08786"
+         y="0.82792366"
+         ry="5.4255653e-16"
+         transform="rotate(-90)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-9"
+         width="0.12246498"
+         height="0.31367663"
+         x="-207.23868"
+         y="208.84772"
+         ry="5.4255642e-16"
+         transform="rotate(-44.99999)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-6"
+         width="0.12246498"
+         height="0.31367663"
+         x="1.9722033"
+         y="293.82111"
+         ry="5.4255653e-16" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-0"
+         width="0.12246498"
+         height="0.31367663"
+         x="209.99203"
+         y="205.97189"
+         ry="5.4255642e-16"
+         transform="rotate(45.000025)" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:2.42406px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0606015"
+         x="1.2795526"
+         y="295.67264"
+         id="text7472"><tspan
+           sodipodi:role="line"
+           id="tspan7470"
+           x="1.2795526"
+           y="295.67264"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:2.42406px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.0606015">e</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/icons/kn-channel-name.svg
+++ b/icons/kn-channel-name.svg
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-channel-name.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.6612081"
+     inkscape:cy="7.5077017"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1821"
+     inkscape:window-height="1141"
+     inkscape:window-x="2617"
+     inkscape:window-y="75"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.0121632;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path821"
+       sodipodi:sides="7"
+       sodipodi:cx="6.2384149"
+       sodipodi:cy="294.99325"
+       sodipodi:r1="1.769226"
+       sodipodi:r2="1.5940177"
+       sodipodi:arg1="1.1246908"
+       sodipodi:arg2="1.5734898"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 7.001757,296.58933 -1.5352712,-0.004 -0.9539929,-1.2029 0.3456614,-1.49586 1.3850257,-0.6624 1.3814374,0.66985 0.3375985,1.4977 z"
+       inkscape:transform-center-x="0.0010604645"
+       inkscape:transform-center-y="-0.086589138" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g15737"
+       transform="matrix(0.89821744,0,0,0.89821744,0.34121819,29.874389)"
+       style="fill:#ffffff">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:1.95874px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0489684"
+         x="1.0540503"
+         y="295.56073"
+         id="text7472-5"><tspan
+           sodipodi:role="line"
+           id="tspan7470-6"
+           x="1.0540503"
+           y="295.56073"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:1.95874px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.0489684">e</tspan></text>
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-9-7"
+         width="0.14225888"
+         height="0.36437586"
+         x="294.96762"
+         y="-0.87293112"
+         ry="6.3024942e-16"
+         transform="rotate(90)" />
+      <g
+         id="g14368"
+         transform="matrix(0.05872322,0,0,0.05872322,0.51973739,293.54815)"
+         style="display:inline;fill:#ffffff">
+        <g
+           id="g14357"
+           transform="translate(0,0.32321547)"
+           style="fill:#ffffff">
+          <ellipse
+             style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path6915-7"
+             cx="25.05979"
+             cy="-45.478432"
+             rx="4.3480296"
+             ry="4.3311458"
+             transform="rotate(90)" />
+          <rect
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="rect6836-1-8-4"
+             width="2.4225321"
+             height="6.2049708"
+             x="23.889864"
+             y="-40.241295"
+             ry="1.0732543e-14"
+             transform="rotate(90)" />
+        </g>
+        <g
+           id="g13703"
+           transform="translate(1.1374415)"
+           style="fill:#ffffff">
+          <ellipse
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path6915-3-0"
+             cx="14.341574"
+             cy="-57.883663"
+             rx="4.3480296"
+             ry="4.3311458"
+             transform="rotate(120.81993)" />
+          <rect
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="rect6836-1-8-7-6"
+             width="2.4225321"
+             height="6.2049708"
+             x="13.192532"
+             y="-52.689426"
+             ry="1.0732543e-14"
+             transform="rotate(120.81993)" />
+        </g>
+        <g
+           id="g13699"
+           style="fill:#ffffff">
+          <ellipse
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path6915-3-9"
+             cx="-29.838108"
+             cy="-32.850937"
+             rx="4.3480296"
+             ry="4.3311458"
+             transform="matrix(-0.51234162,-0.85878173,-0.85878173,0.51234162,0,0)" />
+          <rect
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="rect6836-1-8-7-7"
+             width="2.4225321"
+             height="6.2049708"
+             x="-30.987148"
+             y="-27.6567"
+             ry="1.0732543e-14"
+             transform="matrix(-0.51234162,-0.85878173,-0.85878173,0.51234162,0,0)" />
+        </g>
+      </g>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:0.348544px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.00871363"
+       x="1.2679416"
+       y="296.67007"
+       id="text17672"><tspan
+         sodipodi:role="line"
+         id="tspan17670"
+         x="1.2679416"
+         y="296.67007"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.00871363">CHANNEL</tspan></text>
+  </g>
+</svg>

--- a/icons/kn-channel.svg
+++ b/icons/kn-channel.svg
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-channel.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.6612081"
+     inkscape:cy="7.5077017"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1821"
+     inkscape:window-height="1141"
+     inkscape:window-x="2617"
+     inkscape:window-y="75"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.0121632;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path821"
+       sodipodi:sides="7"
+       sodipodi:cx="6.2384149"
+       sodipodi:cy="294.99325"
+       sodipodi:r1="1.769226"
+       sodipodi:r2="1.5940177"
+       sodipodi:arg1="1.1246908"
+       sodipodi:arg2="1.5734898"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 7.001757,296.58933 -1.5352712,-0.004 -0.9539929,-1.2029 0.3456614,-1.49586 1.3850257,-0.6624 1.3814374,0.66985 0.3375985,1.4977 z"
+       inkscape:transform-center-x="0.0010604645"
+       inkscape:transform-center-y="-0.086589138" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g15737"
+       transform="matrix(0.89821744,0,0,0.89821744,0.34121819,29.874389)"
+       style="fill:#ffffff">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:1.95874px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0489684"
+         x="1.0540503"
+         y="295.56073"
+         id="text7472-5"><tspan
+           sodipodi:role="line"
+           id="tspan7470-6"
+           x="1.0540503"
+           y="295.56073"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:1.95874px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.0489684">e</tspan></text>
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-8-9-7"
+         width="0.14225888"
+         height="0.36437586"
+         x="294.96762"
+         y="-0.87293112"
+         ry="6.3024942e-16"
+         transform="rotate(90)" />
+      <g
+         id="g14368"
+         transform="matrix(0.05872322,0,0,0.05872322,0.51973739,293.54815)"
+         style="display:inline;fill:#ffffff">
+        <g
+           id="g14357"
+           transform="translate(0,0.32321547)"
+           style="fill:#ffffff">
+          <ellipse
+             style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path6915-7"
+             cx="25.05979"
+             cy="-45.478432"
+             rx="4.3480296"
+             ry="4.3311458"
+             transform="rotate(90)" />
+          <rect
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="rect6836-1-8-4"
+             width="2.4225321"
+             height="6.2049708"
+             x="23.889864"
+             y="-40.241295"
+             ry="1.0732543e-14"
+             transform="rotate(90)" />
+        </g>
+        <g
+           id="g13703"
+           transform="translate(1.1374415)"
+           style="fill:#ffffff">
+          <ellipse
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path6915-3-0"
+             cx="14.341574"
+             cy="-57.883663"
+             rx="4.3480296"
+             ry="4.3311458"
+             transform="rotate(120.81993)" />
+          <rect
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="rect6836-1-8-7-6"
+             width="2.4225321"
+             height="6.2049708"
+             x="13.192532"
+             y="-52.689426"
+             ry="1.0732543e-14"
+             transform="rotate(120.81993)" />
+        </g>
+        <g
+           id="g13699"
+           style="fill:#ffffff">
+          <ellipse
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="path6915-3-9"
+             cx="-29.838108"
+             cy="-32.850937"
+             rx="4.3480296"
+             ry="4.3311458"
+             transform="matrix(-0.51234162,-0.85878173,-0.85878173,0.51234162,0,0)" />
+          <rect
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="rect6836-1-8-7-7"
+             width="2.4225321"
+             height="6.2049708"
+             x="-30.987148"
+             y="-27.6567"
+             ry="1.0732543e-14"
+             transform="matrix(-0.51234162,-0.85878173,-0.85878173,0.51234162,0,0)" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/icons/kn-revision-name.svg
+++ b/icons/kn-revision-name.svg
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-revision-name.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="6.6990644"
+     inkscape:cy="7.5369972"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1821"
+     inkscape:window-height="1141"
+     inkscape:window-x="2659"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0"
+     inkscape:snap-grids="true"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-others="true"
+     inkscape:snap-global="false" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.0121632;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path821"
+       sodipodi:sides="7"
+       sodipodi:cx="6.2384149"
+       sodipodi:cy="294.99325"
+       sodipodi:r1="1.769226"
+       sodipodi:r2="1.5940177"
+       sodipodi:arg1="1.1246908"
+       sodipodi:arg2="1.5734898"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 7.001757,296.58933 -1.5352712,-0.004 -0.9539929,-1.2029 0.3456614,-1.49586 1.3850257,-0.6624 1.3814374,0.66985 0.3375985,1.4977 z"
+       inkscape:transform-center-x="0.0010604645"
+       inkscape:transform-center-y="-0.086589138" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g16328"
+       transform="matrix(0.7277976,0,0,0.7277976,-1.4460752,79.710604)">
+      <path
+         id="path18310-4"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 6.123598,293.85601 a 0.61253105,0.60809261 19.978408 0 0 -0.1303664,0.014 0.61253105,0.60809261 19.978408 0 0 -0.4639559,0.72445 0.61253105,0.60809261 19.978408 0 0 0.7306768,0.46475 0.61253105,0.60809261 19.978408 0 0 0.4639558,-0.72445 0.61253105,0.60809261 19.978408 0 0 -0.6003103,-0.47875 z m 0.00107,0.38959 a 0.21901185,0.21901185 0 0 1 0.00194,0 0.21901185,0.21901185 0 0 1 0.2190084,0.21901 0.21901185,0.21901185 0 0 1 -0.2190084,0.21901 0.21901185,0.21901185 0 0 1 -0.2190085,-0.21901 0.21901185,0.21901185 0 0 1 0.2170652,-0.21901 z" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect18387-3"
+         width="0.28475761"
+         height="0.45658252"
+         x="-289.20657"
+         y="-56.007679"
+         ry="1.0996216e-15"
+         transform="matrix(-0.211836,-0.97730523,0.97724799,-0.21209989,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect18387-3-4"
+         width="0.28475761"
+         height="0.45658252"
+         x="-144.93451"
+         y="256.90179"
+         ry="1.0996216e-15"
+         transform="matrix(0.86053995,-0.50938295,0.50961528,0.86040238,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect18387-3-2"
+         width="0.28475761"
+         height="0.45658252"
+         x="200.35324"
+         y="216.07733"
+         ry="1.0996216e-15"
+         transform="matrix(0.74635283,0.66555049,-0.66534892,0.74653253,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect18387-3-26"
+         width="0.28475761"
+         height="0.45658252"
+         x="267.3696"
+         y="-122.91298"
+         ry="1.0996216e-15"
+         transform="matrix(-0.39964437,0.91667027,-0.91677814,-0.39939685,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect18387-3-41"
+         width="0.28475761"
+         height="0.45658252"
+         x="-34.286961"
+         y="-292.15314"
+         ry="1.0996216e-15"
+         transform="matrix(-0.99542819,-0.09551293,0.09524414,-0.99545394,0,0)" />
+      <path
+         style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.222451;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 5.2043393,294.57889 H 3.2709065 v 2.74823 h 2.7481508 v -1.93881"
+         id="path5297" />
+      <rect
+         style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.148301;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect5934"
+         width="1.193947"
+         height="0.58314019"
+         x="3.804733"
+         y="295.03555"
+         ry="3.2293963e-15" />
+      <circle
+         style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.222451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path5936"
+         cx="4.6797967"
+         cy="296.40448"
+         r="0.29959419" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:0.348544px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.00871363"
+       x="1.2853007"
+       y="296.67703"
+       id="text17672"><tspan
+         sodipodi:role="line"
+         id="tspan17670"
+         x="1.2853007"
+         y="296.67703"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.00871363">REVISION</tspan></text>
+  </g>
+</svg>

--- a/icons/kn-revision.svg
+++ b/icons/kn-revision.svg
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-revision.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="6.6990644"
+     inkscape:cy="7.5369972"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1821"
+     inkscape:window-height="1141"
+     inkscape:window-x="2659"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0"
+     inkscape:snap-grids="true"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-others="true"
+     inkscape:snap-global="false" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.0121632;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path821"
+       sodipodi:sides="7"
+       sodipodi:cx="6.2384149"
+       sodipodi:cy="294.99325"
+       sodipodi:r1="1.769226"
+       sodipodi:r2="1.5940177"
+       sodipodi:arg1="1.1246908"
+       sodipodi:arg2="1.5734898"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 7.001757,296.58933 -1.5352712,-0.004 -0.9539929,-1.2029 0.3456614,-1.49586 1.3850257,-0.6624 1.3814374,0.66985 0.3375985,1.4977 z"
+       inkscape:transform-center-x="0.0010604645"
+       inkscape:transform-center-y="-0.086589138" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g16328"
+       transform="matrix(0.7277976,0,0,0.7277976,-1.4460752,79.710604)">
+      <path
+         id="path18310-4"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 6.123598,293.85601 a 0.61253105,0.60809261 19.978408 0 0 -0.1303664,0.014 0.61253105,0.60809261 19.978408 0 0 -0.4639559,0.72445 0.61253105,0.60809261 19.978408 0 0 0.7306768,0.46475 0.61253105,0.60809261 19.978408 0 0 0.4639558,-0.72445 0.61253105,0.60809261 19.978408 0 0 -0.6003103,-0.47875 z m 0.00107,0.38959 a 0.21901185,0.21901185 0 0 1 0.00194,0 0.21901185,0.21901185 0 0 1 0.2190084,0.21901 0.21901185,0.21901185 0 0 1 -0.2190084,0.21901 0.21901185,0.21901185 0 0 1 -0.2190085,-0.21901 0.21901185,0.21901185 0 0 1 0.2170652,-0.21901 z" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect18387-3"
+         width="0.28475761"
+         height="0.45658252"
+         x="-289.20657"
+         y="-56.007679"
+         ry="1.0996216e-15"
+         transform="matrix(-0.211836,-0.97730523,0.97724799,-0.21209989,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect18387-3-4"
+         width="0.28475761"
+         height="0.45658252"
+         x="-144.93451"
+         y="256.90179"
+         ry="1.0996216e-15"
+         transform="matrix(0.86053995,-0.50938295,0.50961528,0.86040238,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect18387-3-2"
+         width="0.28475761"
+         height="0.45658252"
+         x="200.35324"
+         y="216.07733"
+         ry="1.0996216e-15"
+         transform="matrix(0.74635283,0.66555049,-0.66534892,0.74653253,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect18387-3-26"
+         width="0.28475761"
+         height="0.45658252"
+         x="267.3696"
+         y="-122.91298"
+         ry="1.0996216e-15"
+         transform="matrix(-0.39964437,0.91667027,-0.91677814,-0.39939685,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+         id="rect18387-3-41"
+         width="0.28475761"
+         height="0.45658252"
+         x="-34.286961"
+         y="-292.15314"
+         ry="1.0996216e-15"
+         transform="matrix(-0.99542819,-0.09551293,0.09524414,-0.99545394,0,0)" />
+      <path
+         style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.222451;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 5.2043393,294.57889 H 3.2709065 v 2.74823 h 2.7481508 v -1.93881"
+         id="path5297" />
+      <rect
+         style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.148301;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect5934"
+         width="1.193947"
+         height="0.58314019"
+         x="3.804733"
+         y="295.03555"
+         ry="3.2293963e-15" />
+      <circle
+         style="display:inline;fill:none;stroke:#ffffff;stroke-width:0.222451;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path5936"
+         cx="4.6797967"
+         cy="296.40448"
+         r="0.29959419" />
+    </g>
+  </g>
+</svg>

--- a/icons/kn-service-name.svg
+++ b/icons/kn-service-name.svg
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-service-name.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.7851725"
+     inkscape:cy="7.3915495"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1821"
+     inkscape:window-height="1141"
+     inkscape:window-x="2659"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0"
+     inkscape:snap-grids="true"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-others="true"
+     inkscape:snap-global="false" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.0121632;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path821"
+       sodipodi:sides="7"
+       sodipodi:cx="6.2384149"
+       sodipodi:cy="294.99325"
+       sodipodi:r1="1.769226"
+       sodipodi:r2="1.5940177"
+       sodipodi:arg1="1.1246908"
+       sodipodi:arg2="1.5734898"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 7.001757,296.58933 -1.5352712,-0.004 -0.9539929,-1.2029 0.3456614,-1.49586 1.3850257,-0.6624 1.3814374,0.66985 0.3375985,1.4977 z"
+       inkscape:transform-center-x="0.0010604645"
+       inkscape:transform-center-y="-0.086589138" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g16416"
+       transform="matrix(0.8399028,0,0,0.8399028,-2.3833775,46.869717)">
+      <path
+         id="path18310-4"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 6.2150084,293.91883 a 0.50141033,0.49777707 19.978408 0 0 -0.106716,0.0115 0.50141033,0.49777707 19.978408 0 0 -0.3797885,0.59303 0.50141033,0.49777707 19.978408 0 0 0.5981229,0.38044 0.50141033,0.49777707 19.978408 0 0 0.3797885,-0.59303 0.50141033,0.49777707 19.978408 0 0 -0.4914069,-0.3919 z m 8.758e-4,0.31892 a 0.17928039,0.17928039 0 0 1 0.00159,0 0.17928039,0.17928039 0 0 1 0.1792777,0.17928 0.17928039,0.17928039 0 0 1 -0.1792777,0.17927 0.17928039,0.17928039 0 0 1 -0.1792778,-0.17927 0.17928039,0.17928039 0 0 1 0.1776868,-0.17928 z" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18387-3"
+         width="0.23309904"
+         height="0.37375277"
+         x="-289.15356"
+         y="-55.978271"
+         ry="9.0013651e-16"
+         transform="matrix(-0.211836,-0.97730523,0.97724799,-0.21209989,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259"
+         width="0.47272825"
+         height="0.55849165"
+         x="229.58252"
+         y="-185.74808"
+         ry="1.1905626e-15"
+         transform="matrix(-0.61075128,0.7918225,-0.78778442,-0.61595106,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259-4"
+         width="0.47210151"
+         height="0.55922663"
+         x="-0.78502131"
+         y="-296.89008"
+         ry="1.1921293e-15"
+         transform="matrix(-0.99994331,0.01064744,-0.01512397,-0.99988563,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259-9"
+         width="0.4747934"
+         height="0.5560562"
+         x="-231.74878"
+         y="-184.07957"
+         ry="1.1853709e-15"
+         transform="matrix(-0.63174438,-0.77517678,0.77226811,-0.63529676,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259-93"
+         width="0.47422206"
+         height="0.55673212"
+         x="-288.02817"
+         y="64.84153"
+         ry="1.1868117e-15"
+         transform="matrix(0.20675023,-0.97839376,0.97702492,0.21312508,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259-6"
+         width="0.47178271"
+         height="0.55959958"
+         x="-127.21611"
+         y="265.6188"
+         ry="1.1929246e-15"
+         transform="matrix(0.8949225,-0.44622161,0.44470901,0.89567511,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259-0"
+         width="0.47344285"
+         height="0.55765128"
+         x="128.18256"
+         y="264.21616"
+         ry="1.1887714e-15"
+         transform="matrix(0.90494619,0.42552601,-0.41893402,0.90801668,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259-5"
+         width="0.47513935"
+         height="0.55564612"
+         x="288.35611"
+         y="63.645226"
+         ry="1.1844968e-15"
+         transform="matrix(0.23582,0.97179675,-0.97216039,0.23431642,0,0)" />
+      <path
+         id="path18310"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 5.0127563,294.72438 a 0.92395857,0.91726342 70.263479 0 0 -0.718215,0.35525 0.92395857,0.91726342 70.263479 0 0 0.1649602,1.29575 0.92395857,0.91726342 70.263479 0 0 1.2877679,-0.15989 0.92395857,0.91726342 70.263479 0 0 -0.1649603,-1.29576 0.92395857,0.91726342 70.263479 0 0 -0.5695528,-0.19535 z m 0.00467,0.44105 a 0.48212432,0.48212432 0 0 1 0.2085622,0.0458 0.48212432,0.48212432 0 0 1 0.2312236,0.64144 0.48212432,0.48212432 0 0 1 -0.6414327,0.23119 0.48212432,0.48212432 0 0 1 -0.2311911,-0.6414 0.48212432,0.48212432 0 0 1 0.432838,-0.27704 z" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18387-3-4"
+         width="0.23309904"
+         height="0.37375277"
+         x="-144.80627"
+         y="256.83777"
+         ry="9.0013651e-16"
+         transform="matrix(0.86053995,-0.50938295,0.50961528,0.86040238,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18387-3-2"
+         width="0.23309904"
+         height="0.37375277"
+         x="200.41521"
+         y="215.91234"
+         ry="9.0013651e-16"
+         transform="matrix(0.74635283,0.66555049,-0.66534892,0.74653253,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18387-3-26"
+         width="0.23309904"
+         height="0.37375277"
+         x="267.31549"
+         y="-123.04696"
+         ry="9.0013651e-16"
+         transform="matrix(-0.39964437,0.91667027,-0.91677814,-0.39939685,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18387-3-41"
+         width="0.23309904"
+         height="0.37375277"
+         x="-34.347088"
+         y="-292.16605"
+         ry="9.0013651e-16"
+         transform="matrix(-0.99542819,-0.09551293,0.09524414,-0.99545394,0,0)" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:0.348544px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.00871363"
+       x="1.3816268"
+       y="296.67938"
+       id="text17672"><tspan
+         sodipodi:role="line"
+         id="tspan17670"
+         x="1.3816268"
+         y="296.67938"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.00871363">SERVICE</tspan></text>
+  </g>
+</svg>

--- a/icons/kn-service.svg
+++ b/icons/kn-service.svg
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-service.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.7851725"
+     inkscape:cy="7.3915495"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1821"
+     inkscape:window-height="1141"
+     inkscape:window-x="2584"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0"
+     inkscape:snap-grids="true"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-others="true"
+     inkscape:snap-global="false" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.0121632;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path821"
+       sodipodi:sides="7"
+       sodipodi:cx="6.2384149"
+       sodipodi:cy="294.99325"
+       sodipodi:r1="1.769226"
+       sodipodi:r2="1.5940177"
+       sodipodi:arg1="1.1246908"
+       sodipodi:arg2="1.5734898"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 7.001757,296.58933 -1.5352712,-0.004 -0.9539929,-1.2029 0.3456614,-1.49586 1.3850257,-0.6624 1.3814374,0.66985 0.3375985,1.4977 z"
+       inkscape:transform-center-x="0.0010604645"
+       inkscape:transform-center-y="-0.086589138" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g16416"
+       transform="matrix(0.8399028,0,0,0.8399028,-2.3833775,46.869717)">
+      <path
+         id="path18310-4"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 6.2150084,293.91883 a 0.50141033,0.49777707 19.978408 0 0 -0.106716,0.0115 0.50141033,0.49777707 19.978408 0 0 -0.3797885,0.59303 0.50141033,0.49777707 19.978408 0 0 0.5981229,0.38044 0.50141033,0.49777707 19.978408 0 0 0.3797885,-0.59303 0.50141033,0.49777707 19.978408 0 0 -0.4914069,-0.3919 z m 8.758e-4,0.31892 a 0.17928039,0.17928039 0 0 1 0.00159,0 0.17928039,0.17928039 0 0 1 0.1792777,0.17928 0.17928039,0.17928039 0 0 1 -0.1792777,0.17927 0.17928039,0.17928039 0 0 1 -0.1792778,-0.17927 0.17928039,0.17928039 0 0 1 0.1776868,-0.17928 z" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18387-3"
+         width="0.23309904"
+         height="0.37375277"
+         x="-289.15356"
+         y="-55.978271"
+         ry="9.0013651e-16"
+         transform="matrix(-0.211836,-0.97730523,0.97724799,-0.21209989,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259"
+         width="0.47272825"
+         height="0.55849165"
+         x="229.58252"
+         y="-185.74808"
+         ry="1.1905626e-15"
+         transform="matrix(-0.61075128,0.7918225,-0.78778442,-0.61595106,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259-4"
+         width="0.47210151"
+         height="0.55922663"
+         x="-0.78502131"
+         y="-296.89008"
+         ry="1.1921293e-15"
+         transform="matrix(-0.99994331,0.01064744,-0.01512397,-0.99988563,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259-9"
+         width="0.4747934"
+         height="0.5560562"
+         x="-231.74878"
+         y="-184.07957"
+         ry="1.1853709e-15"
+         transform="matrix(-0.63174438,-0.77517678,0.77226811,-0.63529676,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259-93"
+         width="0.47422206"
+         height="0.55673212"
+         x="-288.02817"
+         y="64.84153"
+         ry="1.1868117e-15"
+         transform="matrix(0.20675023,-0.97839376,0.97702492,0.21312508,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259-6"
+         width="0.47178271"
+         height="0.55959958"
+         x="-127.21611"
+         y="265.6188"
+         ry="1.1929246e-15"
+         transform="matrix(0.8949225,-0.44622161,0.44470901,0.89567511,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259-0"
+         width="0.47344285"
+         height="0.55765128"
+         x="128.18256"
+         y="264.21616"
+         ry="1.1887714e-15"
+         transform="matrix(0.90494619,0.42552601,-0.41893402,0.90801668,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18259-5"
+         width="0.47513935"
+         height="0.55564612"
+         x="288.35611"
+         y="63.645226"
+         ry="1.1844968e-15"
+         transform="matrix(0.23582,0.97179675,-0.97216039,0.23431642,0,0)" />
+      <path
+         id="path18310"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 5.0127563,294.72438 a 0.92395857,0.91726342 70.263479 0 0 -0.718215,0.35525 0.92395857,0.91726342 70.263479 0 0 0.1649602,1.29575 0.92395857,0.91726342 70.263479 0 0 1.2877679,-0.15989 0.92395857,0.91726342 70.263479 0 0 -0.1649603,-1.29576 0.92395857,0.91726342 70.263479 0 0 -0.5695528,-0.19535 z m 0.00467,0.44105 a 0.48212432,0.48212432 0 0 1 0.2085622,0.0458 0.48212432,0.48212432 0 0 1 0.2312236,0.64144 0.48212432,0.48212432 0 0 1 -0.6414327,0.23119 0.48212432,0.48212432 0 0 1 -0.2311911,-0.6414 0.48212432,0.48212432 0 0 1 0.432838,-0.27704 z" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18387-3-4"
+         width="0.23309904"
+         height="0.37375277"
+         x="-144.80627"
+         y="256.83777"
+         ry="9.0013651e-16"
+         transform="matrix(0.86053995,-0.50938295,0.50961528,0.86040238,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18387-3-2"
+         width="0.23309904"
+         height="0.37375277"
+         x="200.41521"
+         y="215.91234"
+         ry="9.0013651e-16"
+         transform="matrix(0.74635283,0.66555049,-0.66534892,0.74653253,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18387-3-26"
+         width="0.23309904"
+         height="0.37375277"
+         x="267.31549"
+         y="-123.04696"
+         ry="9.0013651e-16"
+         transform="matrix(-0.39964437,0.91667027,-0.91677814,-0.39939685,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect18387-3-41"
+         width="0.23309904"
+         height="0.37375277"
+         x="-34.347088"
+         y="-292.16605"
+         ry="9.0013651e-16"
+         transform="matrix(-0.99542819,-0.09551293,0.09524414,-0.99545394,0,0)" />
+    </g>
+  </g>
+</svg>

--- a/icons/kn-source-name.svg
+++ b/icons/kn-source-name.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-source-name.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="5.7487819"
+     inkscape:cy="7.7436159"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1821"
+     inkscape:window-height="1141"
+     inkscape:window-x="2055"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0"
+     inkscape:snap-others="true"
+     inkscape:snap-nodes="true" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g15816"
+       transform="translate(0.09341403,-0.24305306)">
+      <path
+         id="path15800"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.744072;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+         d="M 3.2695312,4.2558594 V 4.6328125 11.3125 h 0.033203 C 3.2691483,11.145545 3.2641453,10.865869 3.296875,10.707031 3.3860174,10.274386 3.6415957,9.9100104 4.015625,9.6464844 V 5.3945312 l 2.4765625,1.9414063 c 0.2071268,-0.1725084 0.4507563,-0.2990076 0.7167969,-0.375 L 4.7148438,5.0019531 H 10.601562 L 8.1445312,6.9296875 C 8.4341385,6.9862205 8.7051584,7.0847627 8.9335938,7.25 L 11.308594,5.3886719 v 4.2382812 c 0.02366,0.033445 0.05874,0.067858 0.125,0.125 0.199702,0.1723465 0.386086,0.4319239 0.476562,0.6640629 0.02067,0.05291 0.05372,0.153932 0.07227,0.224609 0.03058,0.116409 0.0332,0.15125 0.0332,0.363281 0,0.181137 -0.0096,0.225016 -0.0293,0.308594 h 0.06836 V 4.2558594 Z"
+         transform="matrix(0.26458333,0,0,0.26458333,0,292.76665)" />
+      <path
+         id="rect12903"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.1084;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 2.0510812,294.44438 a 0.65413024,0.61189087 0 0 0 -0.5603779,0.29986 0.65413024,0.61189087 0 0 0 -0.4626178,0.42543 0.65413024,0.61189087 0 0 0 -0.31588923,0.52373 0.65413024,0.61189087 0 0 0 0.65413983,0.61186 0.65413024,0.61189087 0 0 0 0.00566,-3e-5 v 6.3e-4 h 1.3089873 v -5.6e-4 a 0.65413024,0.61189087 0 0 0 0.6533256,-0.6119 0.65413024,0.61189087 0 0 0 -0.2047547,-0.4446 0.65413024,0.61189087 0 0 0 -0.5228731,-0.51886 0.65413024,0.61189087 0 0 0 -0.5533369,-0.28556 0.65413024,0.61189087 0 0 0 -0.00226,0 z m 3.532e-4,0.0944 a 0.55318815,0.51746692 0 0 1 0.00191,0 0.55318815,0.51746692 0 0 1 0.419169,0.17985 0.65413024,0.61189087 0 0 0 -3.56e-5,0 0.55318815,0.51746692 0 0 1 0.070728,0.0976 0.55318815,0.51746692 0 0 1 2.484e-4,3e-5 0.55318815,0.51746692 0 0 1 0.024414,0.003 0.55318815,0.51746692 0 0 1 3.532e-4,7e-5 0.55318815,0.51746692 0 0 1 2.483e-4,3e-5 0.55318815,0.51746692 0 0 1 0.00134,2e-4 0.55318815,0.51746692 0 0 1 0.012879,0.002 0.55318815,0.51746692 0 0 1 0.00212,3.6e-4 0.55318815,0.51746692 0 0 1 2.483e-4,4e-5 0.55318815,0.51746692 0 0 1 0.008,0.001 0.55318815,0.51746692 0 0 1 2.484e-4,6e-5 0.55318815,0.51746692 0 0 1 0.008,0.002 0.55318815,0.51746692 0 0 1 2.483e-4,6e-5 0.55318815,0.51746692 0 0 1 0.00796,0.002 0.55318815,0.51746692 0 0 1 2.483e-4,6e-5 0.55318815,0.51746692 0 0 1 0.00793,0.002 0.55318815,0.51746692 0 0 1 2.483e-4,7e-5 0.55318815,0.51746692 0 0 1 0.00789,0.002 0.55318815,0.51746692 0 0 1 2.484e-4,7e-5 0.55318815,0.51746692 0 0 1 0.00785,0.002 0.55318815,0.51746692 0 0 1 2.483e-4,6e-5 0.55318815,0.51746692 0 0 1 0.00782,0.002 0.55318815,0.51746692 0 0 1 2.483e-4,7e-5 0.55318815,0.51746692 0 0 1 0.00778,0.002 0.55318815,0.51746692 0 0 1 2.484e-4,6e-5 0.55318815,0.51746692 0 0 1 0.00775,0.002 0.55318815,0.51746692 0 0 1 2.484e-4,6e-5 0.55318815,0.51746692 0 0 1 0.00771,0.003 0.55318815,0.51746692 0 0 1 4.249e-4,1.3e-4 0.55318815,0.51746692 0 0 1 0.3379675,0.31909 0.65413024,0.61189087 0 0 0 -2.483e-4,-1.3e-4 0.55318815,0.51746692 0 0 1 0.028942,0.13312 0.55318815,0.51746692 0 0 1 1.435e-4,1e-4 0.55318815,0.51746692 0 0 1 0.00644,0.005 0.55318815,0.51746692 0 0 1 0.00329,0.003 0.55318815,0.51746692 0 0 1 0.00308,0.003 0.55318815,0.51746692 0 0 1 0.00322,0.003 0.55318815,0.51746692 0 0 1 0.00304,0.003 0.55318815,0.51746692 0 0 1 0.00318,0.003 0.55318815,0.51746692 0 0 1 0.00301,0.003 0.55318815,0.51746692 0 0 1 0.00315,0.003 0.55318815,0.51746692 0 0 1 0.00294,0.003 0.55318815,0.51746692 0 0 1 0.00311,0.003 0.55318815,0.51746692 0 0 1 0.0029,0.003 0.55318815,0.51746692 0 0 1 0.00103,9.6e-4 0.55318815,0.51746692 0 0 1 0.00488,0.005 0.55318815,0.51746692 0 0 1 0.00301,0.003 0.55318815,0.51746692 0 0 1 0.00283,0.003 0.55318815,0.51746692 0 0 1 7.08e-4,7.3e-4 0.55318815,0.51746692 0 0 1 0.00502,0.005 0.55318815,0.51746692 0 0 1 5.679e-4,6e-4 0.55318815,0.51746692 0 0 1 0.010615,0.0112 0.55318815,0.51746692 0 0 1 0.00283,0.003 0.55318815,0.51746692 0 0 1 0.00262,0.003 0.55318815,0.51746692 0 0 1 0.00276,0.003 0.55318815,0.51746692 0 0 1 0.00258,0.003 0.55318815,0.51746692 0 0 1 3.55e-5,6e-5 0.55318815,0.51746692 0 0 1 0.010367,0.0123 0.55318815,0.51746692 0 0 1 0.00262,0.003 0.55318815,0.51746692 0 0 1 4.249e-4,5.7e-4 0.55318815,0.51746692 0 0 1 0.00456,0.006 0.55318815,0.51746692 0 0 1 0.00379,0.005 0.55318815,0.51746692 0 0 1 0.101546,0.29877 0.55318815,0.51746692 0 0 1 -0.5426163,0.51737 v 3e-4 H 2.5796154 1.4733662 1.3860792 v -5.3e-4 a 0.55318815,0.51746692 0 0 1 -0.014082,3e-4 0.55318815,0.51746692 0 0 1 -0.00566,3e-5 0.55318815,0.51746692 0 0 1 -0.55319534,-0.51747 0.55318815,0.51746692 0 0 1 0.19134514,-0.39141 0.65413024,0.61189087 0 0 0 0,3e-5 0.55318815,0.51746692 0 0 1 0.0064,-0.005 0.55318815,0.51746692 0 0 1 0.00651,-0.005 0.55318815,0.51746692 0 0 1 0.00655,-0.005 0.55318815,0.51746692 0 0 1 0.00665,-0.005 0.55318815,0.51746692 0 0 1 0.00672,-0.005 0.55318815,0.51746692 0 0 1 0.00683,-0.005 0.55318815,0.51746692 0 0 1 0.00686,-0.005 0.55318815,0.51746692 0 0 1 0.00697,-0.004 0.55318815,0.51746692 0 0 1 0.00442,-0.003 0.55318815,0.51746692 0 0 1 0.00142,-8.6e-4 0.55318815,0.51746692 0 0 1 0.00265,-0.002 0.55318815,0.51746692 0 0 1 0.00563,-0.003 0.55318815,0.51746692 0 0 1 0.00449,-0.003 0.55318815,0.51746692 0 0 1 0.00219,-0.001 0.55318815,0.51746692 0 0 1 0.0012,-6.7e-4 0.55318815,0.51746692 0 0 1 0.00577,-0.003 0.55318815,0.51746692 0 0 1 0.00159,-8.6e-4 0.55318815,0.51746692 0 0 1 0.013799,-0.007 0.55318815,0.51746692 0 0 1 0.00464,-0.002 0.55318815,0.51746692 0 0 1 0.00156,-7.6e-4 0.55318815,0.51746692 0 0 1 0.00276,-0.001 0.55318815,0.51746692 0 0 1 0.00534,-0.003 0.55318815,0.51746692 0 0 1 0.4421672,-0.40558 0.55318815,0.51746692 0 0 1 0.4938245,-0.28784 z" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:1.84071px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0460178"
+         x="1.4500464"
+         y="295.97025"
+         id="text7472-4"><tspan
+           sodipodi:role="line"
+           id="tspan7470-7"
+           x="1.4500464"
+           y="295.97025"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:1.84071px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.0460178">e</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:0.348544px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.00871363"
+       x="1.3967736"
+       y="296.67136"
+       id="text17672"><tspan
+         sodipodi:role="line"
+         id="tspan17670"
+         x="1.3967736"
+         y="296.67136"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.00871363">SOURCE</tspan></text>
+  </g>
+</svg>

--- a/icons/kn-source.svg
+++ b/icons/kn-source.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-source.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="6.03118"
+     inkscape:cy="7.7191767"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1821"
+     inkscape:window-height="1141"
+     inkscape:window-x="2055"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0"
+     inkscape:snap-others="true"
+     inkscape:snap-nodes="true" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g15816"
+       transform="translate(0.09341403,-0.24305306)">
+      <path
+         id="path15800"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.744072;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+         d="M 3.2695312,4.2558594 V 4.6328125 11.3125 h 0.033203 C 3.2691483,11.145545 3.2641453,10.865869 3.296875,10.707031 3.3860174,10.274386 3.6415957,9.9100104 4.015625,9.6464844 V 5.3945312 l 2.4765625,1.9414063 c 0.2071268,-0.1725084 0.4507563,-0.2990076 0.7167969,-0.375 L 4.7148438,5.0019531 H 10.601562 L 8.1445312,6.9296875 C 8.4341385,6.9862205 8.7051584,7.0847627 8.9335938,7.25 L 11.308594,5.3886719 v 4.2382812 c 0.02366,0.033445 0.05874,0.067858 0.125,0.125 0.199702,0.1723465 0.386086,0.4319239 0.476562,0.6640629 0.02067,0.05291 0.05372,0.153932 0.07227,0.224609 0.03058,0.116409 0.0332,0.15125 0.0332,0.363281 0,0.181137 -0.0096,0.225016 -0.0293,0.308594 h 0.06836 V 4.2558594 Z"
+         transform="matrix(0.26458333,0,0,0.26458333,0,292.76665)" />
+      <path
+         id="rect12903"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.1084;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 2.0510812,294.44438 a 0.65413024,0.61189087 0 0 0 -0.5603779,0.29986 0.65413024,0.61189087 0 0 0 -0.4626178,0.42543 0.65413024,0.61189087 0 0 0 -0.31588923,0.52373 0.65413024,0.61189087 0 0 0 0.65413983,0.61186 0.65413024,0.61189087 0 0 0 0.00566,-3e-5 v 6.3e-4 h 1.3089873 v -5.6e-4 a 0.65413024,0.61189087 0 0 0 0.6533256,-0.6119 0.65413024,0.61189087 0 0 0 -0.2047547,-0.4446 0.65413024,0.61189087 0 0 0 -0.5228731,-0.51886 0.65413024,0.61189087 0 0 0 -0.5533369,-0.28556 0.65413024,0.61189087 0 0 0 -0.00226,0 z m 3.532e-4,0.0944 a 0.55318815,0.51746692 0 0 1 0.00191,0 0.55318815,0.51746692 0 0 1 0.419169,0.17985 0.65413024,0.61189087 0 0 0 -3.56e-5,0 0.55318815,0.51746692 0 0 1 0.070728,0.0976 0.55318815,0.51746692 0 0 1 2.484e-4,3e-5 0.55318815,0.51746692 0 0 1 0.024414,0.003 0.55318815,0.51746692 0 0 1 3.532e-4,7e-5 0.55318815,0.51746692 0 0 1 2.483e-4,3e-5 0.55318815,0.51746692 0 0 1 0.00134,2e-4 0.55318815,0.51746692 0 0 1 0.012879,0.002 0.55318815,0.51746692 0 0 1 0.00212,3.6e-4 0.55318815,0.51746692 0 0 1 2.483e-4,4e-5 0.55318815,0.51746692 0 0 1 0.008,0.001 0.55318815,0.51746692 0 0 1 2.484e-4,6e-5 0.55318815,0.51746692 0 0 1 0.008,0.002 0.55318815,0.51746692 0 0 1 2.483e-4,6e-5 0.55318815,0.51746692 0 0 1 0.00796,0.002 0.55318815,0.51746692 0 0 1 2.483e-4,6e-5 0.55318815,0.51746692 0 0 1 0.00793,0.002 0.55318815,0.51746692 0 0 1 2.483e-4,7e-5 0.55318815,0.51746692 0 0 1 0.00789,0.002 0.55318815,0.51746692 0 0 1 2.484e-4,7e-5 0.55318815,0.51746692 0 0 1 0.00785,0.002 0.55318815,0.51746692 0 0 1 2.483e-4,6e-5 0.55318815,0.51746692 0 0 1 0.00782,0.002 0.55318815,0.51746692 0 0 1 2.483e-4,7e-5 0.55318815,0.51746692 0 0 1 0.00778,0.002 0.55318815,0.51746692 0 0 1 2.484e-4,6e-5 0.55318815,0.51746692 0 0 1 0.00775,0.002 0.55318815,0.51746692 0 0 1 2.484e-4,6e-5 0.55318815,0.51746692 0 0 1 0.00771,0.003 0.55318815,0.51746692 0 0 1 4.249e-4,1.3e-4 0.55318815,0.51746692 0 0 1 0.3379675,0.31909 0.65413024,0.61189087 0 0 0 -2.483e-4,-1.3e-4 0.55318815,0.51746692 0 0 1 0.028942,0.13312 0.55318815,0.51746692 0 0 1 1.435e-4,1e-4 0.55318815,0.51746692 0 0 1 0.00644,0.005 0.55318815,0.51746692 0 0 1 0.00329,0.003 0.55318815,0.51746692 0 0 1 0.00308,0.003 0.55318815,0.51746692 0 0 1 0.00322,0.003 0.55318815,0.51746692 0 0 1 0.00304,0.003 0.55318815,0.51746692 0 0 1 0.00318,0.003 0.55318815,0.51746692 0 0 1 0.00301,0.003 0.55318815,0.51746692 0 0 1 0.00315,0.003 0.55318815,0.51746692 0 0 1 0.00294,0.003 0.55318815,0.51746692 0 0 1 0.00311,0.003 0.55318815,0.51746692 0 0 1 0.0029,0.003 0.55318815,0.51746692 0 0 1 0.00103,9.6e-4 0.55318815,0.51746692 0 0 1 0.00488,0.005 0.55318815,0.51746692 0 0 1 0.00301,0.003 0.55318815,0.51746692 0 0 1 0.00283,0.003 0.55318815,0.51746692 0 0 1 7.08e-4,7.3e-4 0.55318815,0.51746692 0 0 1 0.00502,0.005 0.55318815,0.51746692 0 0 1 5.679e-4,6e-4 0.55318815,0.51746692 0 0 1 0.010615,0.0112 0.55318815,0.51746692 0 0 1 0.00283,0.003 0.55318815,0.51746692 0 0 1 0.00262,0.003 0.55318815,0.51746692 0 0 1 0.00276,0.003 0.55318815,0.51746692 0 0 1 0.00258,0.003 0.55318815,0.51746692 0 0 1 3.55e-5,6e-5 0.55318815,0.51746692 0 0 1 0.010367,0.0123 0.55318815,0.51746692 0 0 1 0.00262,0.003 0.55318815,0.51746692 0 0 1 4.249e-4,5.7e-4 0.55318815,0.51746692 0 0 1 0.00456,0.006 0.55318815,0.51746692 0 0 1 0.00379,0.005 0.55318815,0.51746692 0 0 1 0.101546,0.29877 0.55318815,0.51746692 0 0 1 -0.5426163,0.51737 v 3e-4 H 2.5796154 1.4733662 1.3860792 v -5.3e-4 a 0.55318815,0.51746692 0 0 1 -0.014082,3e-4 0.55318815,0.51746692 0 0 1 -0.00566,3e-5 0.55318815,0.51746692 0 0 1 -0.55319534,-0.51747 0.55318815,0.51746692 0 0 1 0.19134514,-0.39141 0.65413024,0.61189087 0 0 0 0,3e-5 0.55318815,0.51746692 0 0 1 0.0064,-0.005 0.55318815,0.51746692 0 0 1 0.00651,-0.005 0.55318815,0.51746692 0 0 1 0.00655,-0.005 0.55318815,0.51746692 0 0 1 0.00665,-0.005 0.55318815,0.51746692 0 0 1 0.00672,-0.005 0.55318815,0.51746692 0 0 1 0.00683,-0.005 0.55318815,0.51746692 0 0 1 0.00686,-0.005 0.55318815,0.51746692 0 0 1 0.00697,-0.004 0.55318815,0.51746692 0 0 1 0.00442,-0.003 0.55318815,0.51746692 0 0 1 0.00142,-8.6e-4 0.55318815,0.51746692 0 0 1 0.00265,-0.002 0.55318815,0.51746692 0 0 1 0.00563,-0.003 0.55318815,0.51746692 0 0 1 0.00449,-0.003 0.55318815,0.51746692 0 0 1 0.00219,-0.001 0.55318815,0.51746692 0 0 1 0.0012,-6.7e-4 0.55318815,0.51746692 0 0 1 0.00577,-0.003 0.55318815,0.51746692 0 0 1 0.00159,-8.6e-4 0.55318815,0.51746692 0 0 1 0.013799,-0.007 0.55318815,0.51746692 0 0 1 0.00464,-0.002 0.55318815,0.51746692 0 0 1 0.00156,-7.6e-4 0.55318815,0.51746692 0 0 1 0.00276,-0.001 0.55318815,0.51746692 0 0 1 0.00534,-0.003 0.55318815,0.51746692 0 0 1 0.4421672,-0.40558 0.55318815,0.51746692 0 0 1 0.4938245,-0.28784 z" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:1.84071px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0460178"
+         x="1.4500464"
+         y="295.97025"
+         id="text7472-4"><tspan
+           sodipodi:role="line"
+           id="tspan7470-7"
+           x="1.4500464"
+           y="295.97025"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:1.84071px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.0460178">e</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/icons/kn-subscription-name.svg
+++ b/icons/kn-subscription-name.svg
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-subscription-name.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="6.6585256"
+     inkscape:cy="7.8844075"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1821"
+     inkscape:window-height="1141"
+     inkscape:window-x="2980"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.0121632;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path821"
+       sodipodi:sides="7"
+       sodipodi:cx="6.2384149"
+       sodipodi:cy="294.99325"
+       sodipodi:r1="1.769226"
+       sodipodi:r2="1.5940177"
+       sodipodi:arg1="1.1246908"
+       sodipodi:arg2="1.5734898"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 7.001757,296.58933 -1.5352712,-0.004 -0.9539929,-1.2029 0.3456614,-1.49586 1.3850257,-0.6624 1.3814374,0.66985 0.3375985,1.4977 z"
+       inkscape:transform-center-x="0.0010604645"
+       inkscape:transform-center-y="-0.086589138" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g14914"
+       transform="matrix(0.83809053,0,0,0.83809053,3.329335,47.758254)">
+      <path
+         id="path7082"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m -1.44694,293.30648 a 1.5603011,1.5603011 0 0 0 -0.3181692,0.0328 l 0.07289,0.30363 a 1.2482409,1.2482409 0 0 1 0.2403444,-0.0243 1.2482409,1.2482409 0 0 1 0.00493,0 1.2482409,1.2482409 0 0 1 1.24822955,1.24822 1.2482409,1.2482409 0 0 1 -0.33126349,0.84689 l 0.16184207,0.28037 a 1.5603011,1.5603011 0 0 0 0.48149574,-1.12726 1.5603011,1.5603011 0 0 0 -1.56030287,-1.5603 z m -1.0701965,0.42489 a 1.5603011,1.5603011 0 0 0 -0.4901064,1.13541 1.5603011,1.5603011 0 0 0 1.5603029,1.56031 1.5603011,1.5603011 0 0 0 0.3237167,-0.034 l -0.07289,-0.3036 a 1.2482409,1.2482409 0 0 1 -0.2508262,0.0255 1.2482409,1.2482409 0 0 1 -1.2482294,-1.24823 1.2482409,1.2482409 0 0 1 0.3394879,-0.85571 z" />
+      <path
+         id="rect7139"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m -2.0051404,293.58631 -0.9254833,-0.14111 0.7843906,1.06662 z" />
+      <path
+         id="rect7139-0"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m -0.85404635,296.09522 0.92517313,0.14314 -0.78205905,-1.06834 z" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:2.22127px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0555319"
+         x="-2.1719513"
+         y="295.52444"
+         id="text7472"><tspan
+           sodipodi:role="line"
+           id="tspan7470"
+           x="-2.1719513"
+           y="295.52444"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:2.22127px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.0555319">e</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:0.348544px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.00871363"
+       x="1.7597835"
+       y="296.67014"
+       id="text17672"><tspan
+         sodipodi:role="line"
+         id="tspan17670"
+         x="1.7597835"
+         y="296.67014"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.00871363">SUB</tspan></text>
+  </g>
+</svg>

--- a/icons/kn-subscription.svg
+++ b/icons/kn-subscription.svg
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-subscription.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="8.702914"
+     inkscape:cy="7.5319612"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1821"
+     inkscape:window-height="1141"
+     inkscape:window-x="2980"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.0121632;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path821"
+       sodipodi:sides="7"
+       sodipodi:cx="6.2384149"
+       sodipodi:cy="294.99325"
+       sodipodi:r1="1.769226"
+       sodipodi:r2="1.5940177"
+       sodipodi:arg1="1.1246908"
+       sodipodi:arg2="1.5734898"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 7.001757,296.58933 -1.5352712,-0.004 -0.9539929,-1.2029 0.3456614,-1.49586 1.3850257,-0.6624 1.3814374,0.66985 0.3375985,1.4977 z"
+       inkscape:transform-center-x="0.0010604645"
+       inkscape:transform-center-y="-0.086589138" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g14914"
+       transform="matrix(0.83809053,0,0,0.83809053,3.329335,47.758254)">
+      <path
+         id="path7082"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m -1.44694,293.30648 a 1.5603011,1.5603011 0 0 0 -0.3181692,0.0328 l 0.07289,0.30363 a 1.2482409,1.2482409 0 0 1 0.2403444,-0.0243 1.2482409,1.2482409 0 0 1 0.00493,0 1.2482409,1.2482409 0 0 1 1.24822955,1.24822 1.2482409,1.2482409 0 0 1 -0.33126349,0.84689 l 0.16184207,0.28037 a 1.5603011,1.5603011 0 0 0 0.48149574,-1.12726 1.5603011,1.5603011 0 0 0 -1.56030287,-1.5603 z m -1.0701965,0.42489 a 1.5603011,1.5603011 0 0 0 -0.4901064,1.13541 1.5603011,1.5603011 0 0 0 1.5603029,1.56031 1.5603011,1.5603011 0 0 0 0.3237167,-0.034 l -0.07289,-0.3036 a 1.2482409,1.2482409 0 0 1 -0.2508262,0.0255 1.2482409,1.2482409 0 0 1 -1.2482294,-1.24823 1.2482409,1.2482409 0 0 1 0.3394879,-0.85571 z" />
+      <path
+         id="rect7139"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m -2.0051404,293.58631 -0.9254833,-0.14111 0.7843906,1.06662 z" />
+      <path
+         id="rect7139-0"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m -0.85404635,296.09522 0.92517313,0.14314 -0.78205905,-1.06834 z" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:2.22127px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0555319"
+         x="-2.1719513"
+         y="295.52444"
+         id="text7472"><tspan
+           sodipodi:role="line"
+           id="tspan7470"
+           x="-2.1719513"
+           y="295.52444"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:2.22127px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.0555319">e</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/icons/kn-trigger-name.svg
+++ b/icons/kn-trigger-name.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-trigger-name.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.2385573"
+     inkscape:cy="7.6723728"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1821"
+     inkscape:window-height="1141"
+     inkscape:window-x="2659"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0"
+     inkscape:snap-global="false" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.0121632;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path821"
+       sodipodi:sides="7"
+       sodipodi:cx="6.2384149"
+       sodipodi:cy="294.99325"
+       sodipodi:r1="1.769226"
+       sodipodi:r2="1.5940177"
+       sodipodi:arg1="1.1246908"
+       sodipodi:arg2="1.5734898"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 7.001757,296.58933 -1.5352712,-0.004 -0.9539929,-1.2029 0.3456614,-1.49586 1.3850257,-0.6624 1.3814374,0.66985 0.3375985,1.4977 z"
+       inkscape:transform-center-x="0.0010604645"
+       inkscape:transform-center-y="-0.086589138" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g14203"
+       transform="matrix(1.0571292,0,0,1.0571292,-5.6404009,-17.426339)">
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-9-9-3"
+         width="0.35879666"
+         height="0.79896545"
+         x="6.8565946"
+         y="295.86273"
+         ry="1.3819449e-15"
+         transform="matrix(0.99999931,0.00117118,0.0018982,0.9999982,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-9-9-7"
+         width="0.35880554"
+         height="1.2618878"
+         x="239.26077"
+         y="384.04352"
+         ry="2.182647e-15"
+         transform="matrix(-0.99999899,-0.00142158,0.63979913,0.76854218,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-9-9-3-6"
+         width="0.35879666"
+         height="0.79896545"
+         x="-7.8191843"
+         y="295.88434"
+         ry="1.3819449e-15"
+         transform="matrix(-0.99999931,0.00117118,-0.0018982,0.9999982,0,0)" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:1.65851px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0414625"
+         x="6.8216453"
+         y="295.0853"
+         id="text7472"><tspan
+           sodipodi:role="line"
+           id="tspan7470"
+           x="6.8216453"
+           y="295.0853"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:1.65851px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.0414625">e</tspan></text>
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-9-9-7-8"
+         width="0.35880554"
+         height="1.2618878"
+         x="253.95389"
+         y="384.07068"
+         ry="2.182647e-15"
+         transform="matrix(0.99999899,-0.00142158,-0.63979913,0.76854218,0,0)" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:0.348544px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.00871364"
+       x="1.3419732"
+       y="296.67358"
+       id="text17672"><tspan
+         sodipodi:role="line"
+         id="tspan17670"
+         x="1.3419732"
+         y="296.67358"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.00871364">TRIGGER</tspan></text>
+  </g>
+</svg>

--- a/icons/kn-trigger.svg
+++ b/icons/kn-trigger.svg
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="kn-trigger.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="7.2385573"
+     inkscape:cy="7.6723728"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1821"
+     inkscape:window-height="1141"
+     inkscape:window-x="2659"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:document-rotation="0"
+     inkscape:snap-global="false" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76665)">
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.0121632;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path821"
+       sodipodi:sides="7"
+       sodipodi:cx="6.2384149"
+       sodipodi:cy="294.99325"
+       sodipodi:r1="1.769226"
+       sodipodi:r2="1.5940177"
+       sodipodi:arg1="1.1246908"
+       sodipodi:arg2="1.5734898"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 7.001757,296.58933 -1.5352712,-0.004 -0.9539929,-1.2029 0.3456614,-1.49586 1.3850257,-0.6624 1.3814374,0.66985 0.3375985,1.4977 z"
+       inkscape:transform-center-x="0.0010604645"
+       inkscape:transform-center-y="-0.086589138" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.04429172;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path823"
+       sodipodi:sides="9"
+       sodipodi:cx="3.3682271"
+       sodipodi:cy="293.93885"
+       sodipodi:r1="0.85589981"
+       sodipodi:r2="0.76630896"
+       sodipodi:arg1="1.2193516"
+       sodipodi:arg2="1.5684175"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 3.6628744,294.74243 -0.5854683,0.001 -0.4493899,-0.37527 -0.1030371,-0.57633 0.2915279,-0.50772 0.5496839,-0.20155 0.5506366,0.19893 0.2939403,0.50633 -0.1002939,0.57682 z"
+       inkscape:transform-center-x="-0.0014770388"
+       inkscape:transform-center-y="-0.040690139" />
+    <path
+       id="path987"
+       style="opacity:1;fill:#6594cb;fill-opacity:1;stroke:none;stroke-width:0.000570088;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.1113337,292.80276 c -0.00208,3e-5 -0.3127796,0.11352 -0.6906001,0.25205 l -0.68660152,0.25207 -0.36529837,0.63593 c -0.20070933,0.3496 -0.36423208,0.63774 -0.36396532,0.64128 0.00120484,0.0154 0.25438954,1.42754 0.25730999,1.43453 0.001807,0.005 0.25427345,0.21981 0.56261306,0.47728 l 0.56127926,0.46797 0.7052659,-9.9e-4 c 0.388194,-2e-4 0.7203008,-9.9e-4 0.7372635,-0.003 l 0.030662,-0.003 0.5586136,-0.47059 c 0.306998,-0.25888 0.5589222,-0.47246 0.5599461,-0.47597 0.00103,-0.003 0.058147,-0.32959 0.1266555,-0.72393 l 0.123988,-0.71726 -0.3679649,-0.63461 -0.3692978,-0.63461 -0.037332,-0.0128 c -0.020743,-0.008 -0.3301724,-0.11997 -0.6879341,-0.24921 -0.3577616,-0.12926 -0.6525567,-0.23477 -0.6546044,-0.23477 z" />
+    <g
+       id="g14203"
+       transform="matrix(1.0571292,0,0,1.0571292,-5.6404009,-17.426339)">
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-9-9-3"
+         width="0.35879666"
+         height="0.79896545"
+         x="6.8565946"
+         y="295.86273"
+         ry="1.3819449e-15"
+         transform="matrix(0.99999931,0.00117118,0.0018982,0.9999982,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-9-9-7"
+         width="0.35880554"
+         height="1.2618878"
+         x="239.26077"
+         y="384.04352"
+         ry="2.182647e-15"
+         transform="matrix(-0.99999899,-0.00142158,0.63979913,0.76854218,0,0)" />
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-9-9-3-6"
+         width="0.35879666"
+         height="0.79896545"
+         x="-7.8191843"
+         y="295.88434"
+         ry="1.3819449e-15"
+         transform="matrix(-0.99999931,0.00117118,-0.0018982,0.9999982,0,0)" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:1.65851px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0414625"
+         x="6.8216453"
+         y="295.0853"
+         id="text7472"><tspan
+           sodipodi:role="line"
+           id="tspan7470"
+           x="6.8216453"
+           y="295.0853"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:1.65851px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1;stroke-width:0.0414625">e</tspan></text>
+      <rect
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect6836-1-9-9-7-8"
+         width="0.35880554"
+         height="1.2618878"
+         x="253.95389"
+         y="384.07068"
+         ry="2.182647e-15"
+         transform="matrix(0.99999899,-0.00142158,-0.63979913,0.76854218,0,0)" />
+    </g>
+  </g>
+</svg>

--- a/icons/revision.svg
+++ b/icons/revision.svg
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="50mm"
+   height="50mm"
+   viewBox="0 0 50 50"
+   version="1.1"
+   id="svg855"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="revision.svg">
+  <defs
+     id="defs849" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284272"
+     inkscape:cx="172.97417"
+     inkscape:cy="94.694201"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1900"
+     inkscape:window-height="1139"
+     inkscape:window-x="4592"
+     inkscape:window-y="63"
+     inkscape:window-maximized="0"
+     units="mm"
+     inkscape:pagecheckerboard="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2210" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata852">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2"
+     style="display:none">
+    <rect
+       style="display:inline;fill:#1a1a1a;fill-opacity:1;stroke:#000000;stroke-width:0"
+       id="rect9364"
+       width="50.11438"
+       height="50.120899"
+       x="-0.023077769"
+       y="0.053396609"
+       ry="3.9999444e-14" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline">
+    <path
+       id="path18310-4"
+       style="fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 38.675536,3.3295888 a 7.9809701,7.9231394 19.978408 0 0 -1.69861,0.182418 7.9809701,7.9231394 19.978408 0 0 -6.04511,9.4392172 7.9809701,7.9231394 19.978408 0 0 9.52035,6.055444 7.9809701,7.9231394 19.978408 0 0 6.04511,-9.4392172 7.9809701,7.9231394 19.978408 0 0 -7.82174,-6.237862 z m 0.0139,5.076176 a 2.8536138,2.8536138 0 0 1 0.0253,0 2.8536138,2.8536138 0 0 1 2.85357,2.8535722 2.8536138,2.8536138 0 0 1 -2.85357,2.853573 2.8536138,2.8536138 0 0 1 -2.85357,-2.853573 2.8536138,2.8536138 0 0 1 2.82825,-2.8535722 z" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18387-3"
+       width="3.7102478"
+       height="5.9490395"
+       x="-21.067019"
+       y="40.440811"
+       ry="1.4327513e-14"
+       transform="matrix(-0.211836,-0.97730523,0.97724799,-0.21209989,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18387-3-4"
+       width="3.7102478"
+       height="5.9490395"
+       x="25.719782"
+       y="34.392712"
+       ry="1.4327513e-14"
+       transform="matrix(0.86053996,-0.50938294,0.50961529,0.86040238,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18387-3-2"
+       width="3.7102478"
+       height="5.9490395"
+       x="34.540596"
+       y="-12.40672"
+       ry="1.4327513e-14"
+       transform="matrix(0.74635284,0.66555048,-0.66534892,0.74653253,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18387-3-26"
+       width="3.7102478"
+       height="5.9490395"
+       x="-6.992774"
+       y="-34.98209"
+       ry="1.4327513e-14"
+       transform="matrix(-0.39964438,0.91667026,-0.91677814,-0.39939684,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18387-3-41"
+       width="3.7102478"
+       height="5.9490395"
+       x="-41.463612"
+       y="-2.5578344"
+       ry="1.4327513e-14"
+       transform="matrix(-0.99542819,-0.09551293,0.09524414,-0.99545394,0,0)" />
+    <path
+       style="display:inline;fill:none;stroke:#3e94cb;stroke-width:2.89843;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 26.698061,12.748412 -25.1916545,-10e-7 V 48.556473 H 37.313425 V 23.294669"
+       id="path5297" />
+    <rect
+       style="fill:none;stroke:#3e94cb;stroke-width:1.93229;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5934"
+       width="15.556524"
+       height="7.598022"
+       x="8.4618959"
+       y="18.698484"
+       ry="4.2077402e-14" />
+    <circle
+       style="fill:none;stroke:#3e94cb;stroke-width:2.89843;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path5936"
+       cx="19.863533"
+       cy="36.53476"
+       r="3.9035609" />
+  </g>
+</svg>

--- a/icons/service.svg
+++ b/icons/service.svg
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="50mm"
+   height="50mm"
+   viewBox="0 0 50 50"
+   version="1.1"
+   id="svg855"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="service.svg">
+  <defs
+     id="defs849" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="93.416349"
+     inkscape:cy="104.07465"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1900"
+     inkscape:window-height="1139"
+     inkscape:window-x="4825"
+     inkscape:window-y="52"
+     inkscape:window-maximized="0"
+     units="mm"
+     inkscape:pagecheckerboard="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2210" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata852">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Layer 2"
+     style="display:none">
+    <rect
+       style="display:inline;fill:#1a1a1a;fill-opacity:1;stroke:#000000;stroke-width:0"
+       id="rect9364"
+       width="50.11438"
+       height="50.120899"
+       x="-0.023077769"
+       y="0.053396609"
+       ry="3.9999444e-14" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline">
+    <path
+       id="path18310-4"
+       style="fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 146.73633 12.443359 A 30.164297 29.945724 19.978408 0 0 140.31641 13.132812 A 30.164297 29.945724 19.978408 0 0 117.46875 48.808594 A 30.164297 29.945724 19.978408 0 0 153.45117 71.695312 A 30.164297 29.945724 19.978408 0 0 176.29883 36.019531 A 30.164297 29.945724 19.978408 0 0 146.73633 12.443359 z M 146.78906 31.628906 A 10.785312 10.785312 0 0 1 146.88477 31.628906 A 10.785312 10.785312 0 0 1 157.66992 42.414062 A 10.785312 10.785312 0 0 1 146.88477 53.199219 A 10.785312 10.785312 0 0 1 136.09961 42.414062 A 10.785312 10.785312 0 0 1 146.78906 31.628906 z "
+       transform="scale(0.26458333)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18387-3"
+       width="3.7102478"
+       height="5.9490395"
+       x="-21.062071"
+       y="40.593792"
+       ry="1.4327513e-14"
+       transform="matrix(-0.211836,-0.97730523,0.97724799,-0.21209989,0,0)" />
+    <rect
+       style="fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18259"
+       width="7.524436"
+       height="8.8895359"
+       x="8.3019657"
+       y="-53.629807"
+       ry="1.8950238e-14"
+       transform="matrix(-0.61075128,0.7918225,-0.78778442,-0.61595106,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18259-4"
+       width="7.5144606"
+       height="8.9012337"
+       x="-23.106586"
+       y="-50.164116"
+       ry="1.8975174e-14"
+       transform="matrix(-0.99994331,0.01064744,-0.01512397,-0.99988563,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18259-9"
+       width="7.5573072"
+       height="8.850771"
+       x="-40.161373"
+       y="-23.138681"
+       ry="1.8867601e-14"
+       transform="matrix(-0.63174439,-0.77517677,0.77226811,-0.63529675,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18259-93"
+       width="7.5482135"
+       height="8.8615294"
+       x="-29.651745"
+       y="6.6987576"
+       ry="1.8890534e-14"
+       transform="matrix(0.20675023,-0.97839376,0.97702492,0.21312508,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18259-6"
+       width="7.5093861"
+       height="8.9071712"
+       x="0.29442176"
+       y="17.255388"
+       ry="1.8987833e-14"
+       transform="matrix(0.8949225,-0.44622161,0.44470901,0.89567511,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18259-0"
+       width="7.5358105"
+       height="8.8761597"
+       x="27.134146"
+       y="0.35562238"
+       ry="1.8921725e-14"
+       transform="matrix(0.9049462,0.42552601,-0.41893402,0.90801668,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18259-5"
+       width="7.5628138"
+       height="8.844244"
+       x="30.812971"
+       y="-31.016676"
+       ry="1.8853688e-14"
+       transform="matrix(0.23582,0.97179675,-0.97216039,0.23431642,0,0)" />
+    <path
+       id="path18310"
+       style="fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 74.410156 60.904297 A 55.584335 55.181565 70.263479 0 0 31.203125 82.275391 A 55.584335 55.181565 70.263479 0 0 41.126953 160.22656 A 55.584335 55.181565 70.263479 0 0 118.59766 150.60742 A 55.584335 55.181565 70.263479 0 0 108.67383 72.65625 A 55.584335 55.181565 70.263479 0 0 74.410156 60.904297 z M 74.691406 87.4375 A 29.004072 29.004072 0 0 1 87.238281 90.193359 A 29.004072 29.004072 0 0 1 101.14844 128.78125 A 29.004072 29.004072 0 0 1 62.560547 142.68945 A 29.004072 29.004072 0 0 1 48.652344 104.10352 A 29.004072 29.004072 0 0 1 74.691406 87.4375 z "
+       transform="scale(0.26458333)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18387-3-4"
+       width="3.7102478"
+       height="5.9490395"
+       x="25.866514"
+       y="34.436241"
+       ry="1.4327513e-14"
+       transform="matrix(0.86053996,-0.50938294,0.50961529,0.86040238,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18387-3-2"
+       width="3.7102478"
+       height="5.9490395"
+       x="34.626617"
+       y="-12.533351"
+       ry="1.4327513e-14"
+       transform="matrix(0.74635284,0.66555048,-0.66534892,0.74653253,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18387-3-26"
+       width="3.7102478"
+       height="5.9490395"
+       x="-7.0862455"
+       y="-35.103275"
+       ry="1.4327513e-14"
+       transform="matrix(-0.39964438,0.91667026,-0.91677814,-0.39939684,0,0)" />
+    <rect
+       style="display:inline;fill:#3e94cb;fill-opacity:1;stroke:#2592b0;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect18387-3-41"
+       width="3.7102478"
+       height="5.9490395"
+       x="-41.607834"
+       y="-2.5065429"
+       ry="1.4327513e-14"
+       transform="matrix(-0.99542819,-0.09551293,0.09524414,-0.99545394,0,0)" />
+  </g>
+</svg>

--- a/icons/source-generic.svg
+++ b/icons/source-generic.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="50mm"
+   height="50mm"
+   viewBox="0 0 50 50"
+   version="1.1"
+   id="svg855"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="source-generic.svg">
+  <defs
+     id="defs849" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.196421"
+     inkscape:cx="124.24596"
+     inkscape:cy="110.95056"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1531"
+     inkscape:window-height="1048"
+     inkscape:window-x="2949"
+     inkscape:window-y="190"
+     inkscape:window-maximized="0"
+     units="mm"
+     inkscape:pagecheckerboard="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2210" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata852">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:none">
+    <rect
+       style="display:inline;opacity:1;fill:#3d8037;fill-opacity:0.400538;stroke-width:0.2732;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212"
+       width="75"
+       height="75"
+       x="0.059107598"
+       y="0.091476537"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#3d5238;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9"
+       width="75"
+       height="75"
+       x="75.059105"
+       y="0.091476537"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#905238;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9-3"
+       width="75"
+       height="75"
+       x="75.059105"
+       y="75.091476"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#9052ac;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9-3-6"
+       width="75"
+       height="75"
+       x="0.059107598"
+       y="75.091476"
+       ry="5.9678059e-14" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline">
+    <rect
+       style="fill:none;stroke:#2592b0;stroke-width:3.56745"
+       id="rect12930"
+       width="38.542324"
+       height="30.243765"
+       x="5.8033004"
+       y="4.7970524" />
+    <path
+       style="fill:none;stroke:#2592b0;stroke-width:3.53665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.8033005,4.7970525 44.345628,35.040816"
+       id="path12932" />
+    <path
+       style="fill:none;stroke:#2592b0;stroke-width:3.53665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 44.345628,4.7970525 5.8033005,35.040816"
+       id="path12934" />
+    <g
+       id="g12928"
+       transform="matrix(1,0,0,1.1632524,0,-7.5864094)">
+      <path
+         id="rect12903"
+         style="fill:#2592b0;fill-opacity:1;stroke:#2592b0;stroke-width:1.82127;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 25.504269,17.472555 a 11.853471,9.5319413 0 0 0 -10.154589,4.671174 11.853471,9.5319413 0 0 0 -8.3830807,6.627293 11.853471,9.5319413 0 0 0 -5.7242173,8.158569 11.853471,9.5319413 0 0 0 11.853644,9.531563 11.853471,9.5319413 0 0 0 0.102589,-5.13e-4 v 0.0098 h 23.720112 v -0.0088 a 11.853471,9.5319413 0 0 0 11.838891,-9.53205 11.853471,9.5319413 0 0 0 -3.710353,-6.925812 11.853471,9.5319413 0 0 0 -9.474965,-8.082782 11.853471,9.5319413 0 0 0 -10.026998,-4.448442 11.853471,9.5319413 0 0 0 -0.04103,0 z m 0.0064,1.470956 a 10.024303,8.0610196 0 0 1 0.03462,0 10.024303,8.0610196 0 0 1 7.595746,2.801673 11.853471,9.5319413 0 0 0 -6.44e-4,0 10.024303,8.0610196 0 0 1 1.281665,1.520967 10.024303,8.0610196 0 0 1 0.0045,5.16e-4 10.024303,8.0610196 0 0 1 0.442399,0.04795 10.024303,8.0610196 0 0 1 0.0064,9.96e-4 10.024303,8.0610196 0 0 1 0.0045,5.16e-4 10.024303,8.0610196 0 0 1 0.02437,0.0031 10.024303,8.0610196 0 0 1 0.23338,0.033 10.024303,8.0610196 0 0 1 0.03848,0.0057 10.024303,8.0610196 0 0 1 0.0045,5.16e-4 10.024303,8.0610196 0 0 1 0.144899,0.0232 10.024303,8.0610196 0 0 1 0.0045,9.97e-4 10.024303,8.0610196 0 0 1 0.144899,0.02475 10.024303,8.0610196 0 0 1 0.0045,9.97e-4 10.024303,8.0610196 0 0 1 0.144261,0.0263 10.024303,8.0610196 0 0 1 0.0045,9.97e-4 10.024303,8.0610196 0 0 1 0.143618,0.02836 10.024303,8.0610196 0 0 1 0.0045,9.97e-4 10.024303,8.0610196 0 0 1 0.142979,0.03042 10.024303,8.0610196 0 0 1 0.0045,9.97e-4 10.024303,8.0610196 0 0 1 0.142335,0.03197 10.024303,8.0610196 0 0 1 0.0045,9.97e-4 10.024303,8.0610196 0 0 1 0.141696,0.03351 10.024303,8.0610196 0 0 1 0.0045,9.97e-4 10.024303,8.0610196 0 0 1 0.141054,0.03558 10.024303,8.0610196 0 0 1 0.0045,9.97e-4 10.024303,8.0610196 0 0 1 0.140412,0.03712 10.024303,8.0610196 0 0 1 0.0045,9.97e-4 10.024303,8.0610196 0 0 1 0.139773,0.03918 10.024303,8.0610196 0 0 1 0.0077,0.0021 10.024303,8.0610196 0 0 1 6.124297,4.970726 11.853471,9.5319413 0 0 0 -0.0045,-0.002 10.024303,8.0610196 0 0 1 0.524464,2.073672 10.024303,8.0610196 0 0 1 0.0026,0.0015 10.024303,8.0610196 0 0 1 0.11669,0.07888 10.024303,8.0610196 0 0 1 0.05963,0.04125 10.024303,8.0610196 0 0 1 0.05578,0.03919 10.024303,8.0610196 0 0 1 0.05834,0.04176 10.024303,8.0610196 0 0 1 0.05514,0.04021 10.024303,8.0610196 0 0 1 0.0577,0.04227 10.024303,8.0610196 0 0 1 0.05449,0.04073 10.024303,8.0610196 0 0 1 0.05706,0.04331 10.024303,8.0610196 0 0 1 0.05321,0.04125 10.024303,8.0610196 0 0 1 0.05642,0.04434 10.024303,8.0610196 0 0 1 0.05258,0.04176 10.024303,8.0610196 0 0 1 0.01859,0.01494 10.024303,8.0610196 0 0 1 0.08848,0.07218 10.024303,8.0610196 0 0 1 0.05449,0.04537 10.024303,8.0610196 0 0 1 0.05129,0.04331 10.024303,8.0610196 0 0 1 0.01283,0.01135 10.024303,8.0610196 0 0 1 0.09104,0.07836 10.024303,8.0610196 0 0 1 0.01029,0.0093 10.024303,8.0610196 0 0 1 0.192348,0.174268 10.024303,8.0610196 0 0 1 0.05129,0.04796 10.024303,8.0610196 0 0 1 0.04744,0.04537 10.024303,8.0610196 0 0 1 0.05002,0.04846 10.024303,8.0610196 0 0 1 0.04681,0.0464 10.024303,8.0610196 0 0 1 6.42e-4,9.58e-4 10.024303,8.0610196 0 0 1 0.187857,0.191798 10.024303,8.0610196 0 0 1 0.04744,0.05052 10.024303,8.0610196 0 0 1 0.0077,0.0088 10.024303,8.0610196 0 0 1 0.08271,0.08971 10.024303,8.0610196 0 0 1 0.0686,0.07734 10.024303,8.0610196 0 0 1 1.840111,4.654159 10.024303,8.0610196 0 0 1 -9.832731,8.059578 v 0.0046 H 35.081818 15.035516 13.45379 v -0.0082 a 10.024303,8.0610196 0 0 1 -0.255179,0.0046 10.024303,8.0610196 0 0 1 -0.102589,5.16e-4 10.024303,8.0610196 0 0 1 -10.0244338,-8.061125 10.024303,8.0610196 0 0 1 3.4673575,-6.097272 11.853471,9.5319413 0 0 0 0,5.15e-4 10.024303,8.0610196 0 0 1 0.1160488,-0.0794 10.024303,8.0610196 0 0 1 0.1179723,-0.07836 10.024303,8.0610196 0 0 1 0.1186133,-0.0763 10.024303,8.0610196 0 0 1 0.1205367,-0.07528 10.024303,8.0610196 0 0 1 0.1218191,-0.07373 10.024303,8.0610196 0 0 1 0.1237428,-0.07217 10.024303,8.0610196 0 0 1 0.1243839,-0.07064 10.024303,8.0610196 0 0 1 0.126307,-0.06907 10.024303,8.0610196 0 0 1 0.080143,-0.0433 10.024303,8.0610196 0 0 1 0.025646,-0.0134 10.024303,8.0610196 0 0 1 0.048086,-0.02526 10.024303,8.0610196 0 0 1 0.1019435,-0.05207 10.024303,8.0610196 0 0 1 0.081426,-0.04125 10.024303,8.0610196 0 0 1 0.03975,-0.01907 10.024303,8.0610196 0 0 1 0.021799,-0.01031 10.024303,8.0610196 0 0 1 0.1045073,-0.05053 10.024303,8.0610196 0 0 1 0.028853,-0.0134 10.024303,8.0610196 0 0 1 0.2500499,-0.113429 10.024303,8.0610196 0 0 1 0.083992,-0.03712 10.024303,8.0610196 0 0 1 0.028211,-0.01186 10.024303,8.0610196 0 0 1 0.05001,-0.02115 10.024303,8.0610196 0 0 1 0.096815,-0.04021 10.024303,8.0610196 0 0 1 8.0124957,-6.317927 10.024303,8.0610196 0 0 1 8.948577,-4.484018 z" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:#2592b0;stroke-width:0.432522;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 12.014333,43.999449 C 10.740241,43.879701 9.2867999,43.460027 8.1728887,42.890248 6.0982655,41.829051 4.7049773,40.218207 4.1901487,38.285618 4.0106445,37.611786 3.9955577,36.375712 4.1585376,35.695704 4.6778885,33.528795 6.3277817,31.744525 8.8114757,30.663803 L 9.3590709,30.42553 9.4654871,30.003916 C 10.180435,27.17133 13.081444,24.894812 16.651274,24.364989 l 0.497191,-0.07379 0.266467,-0.426207 c 1.639858,-2.622904 5.266229,-4.226887 8.927986,-3.948945 2.125027,0.161298 4.035213,0.844638 5.531342,1.978752 0.559316,0.42398 1.353947,1.256601 1.685943,1.766544 l 0.300638,0.461781 0.512475,0.06704 c 2.599348,0.340045 4.584583,1.219777 6.051758,2.681762 1.121839,1.117869 1.805335,2.465686 1.936004,3.817696 0.04524,0.468113 0.121428,0.570002 0.806411,1.07847 0.957474,0.710739 1.854618,1.785975 2.288407,2.742681 0.09921,0.218804 0.253122,0.635908 0.342022,0.926897 0.146582,0.479795 0.161636,0.618823 0.161636,1.492759 0,0.873936 -0.01505,1.012964 -0.161636,1.492759 -0.604626,1.979061 -1.947778,3.475589 -4.065868,4.53016 -1.153605,0.574363 -2.393934,0.914144 -3.843382,1.05287 -0.78725,0.07535 -25.068213,0.06899 -25.874335,-0.0068 z"
+         id="path13295" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:33.3555px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#2592b0;fill-opacity:1;stroke:none;stroke-width:0.833887"
+       x="14.62644"
+       y="40.654625"
+       id="text7472"><tspan
+         sodipodi:role="line"
+         id="tspan7470"
+         x="14.62644"
+         y="40.654625"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:33.3555px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#2592b0;fill-opacity:1;stroke-width:0.833887">e</tspan></text>
+  </g>
+</svg>

--- a/icons/subscription.svg
+++ b/icons/subscription.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="50mm"
+   height="50mm"
+   viewBox="0 0 50 50"
+   version="1.1"
+   id="svg855"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="subscription.svg">
+  <defs
+     id="defs849" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.196421"
+     inkscape:cx="94.620509"
+     inkscape:cy="91.557514"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1531"
+     inkscape:window-height="1048"
+     inkscape:window-x="2863"
+     inkscape:window-y="244"
+     inkscape:window-maximized="0"
+     units="mm"
+     inkscape:pagecheckerboard="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2210" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata852">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:none">
+    <rect
+       style="display:inline;opacity:1;fill:#3d8037;fill-opacity:0.400538;stroke-width:0.2732;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212"
+       width="75"
+       height="75"
+       x="0.059107598"
+       y="0.091476537"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#3d5238;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9"
+       width="75"
+       height="75"
+       x="75.059105"
+       y="0.091476537"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#905238;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9-3"
+       width="75"
+       height="75"
+       x="75.059105"
+       y="75.091476"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#9052ac;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9-3-6"
+       width="75"
+       height="75"
+       x="0.059107598"
+       y="75.091476"
+       ry="5.9678059e-14" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline">
+    <path
+       id="path7082"
+       style="fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 25.008366,0.00485703 a 24.996796,24.996796 0 0 0 -5.097227,0.5254821 l 1.167736,4.86419637 a 19.997437,19.997437 0 0 1 3.850436,-0.390107 19.997437,19.997437 0 0 1 0.07904,0 A 19.997437,19.997437 0 0 1 45.005605,25.00168 19.997437,19.997437 0 0 1 39.6986,38.56914 l 2.592789,4.491655 A 24.996796,24.996796 0 0 0 50.005189,25.00168 24.996796,24.996796 0 0 0 25.008366,0.00485703 Z M 7.863288,6.8118385 A 24.996796,24.996796 0 0 0 0.01154278,25.00168 24.996796,24.996796 0 0 0 25.008366,49.998502 24.996796,24.996796 0 0 0 30.194467,49.454418 L 29.026726,44.59074 A 19.997437,19.997437 0 0 1 25.008366,44.998929 19.997437,19.997437 0 0 1 5.0111143,25.00168 19.997437,19.997437 0 0 1 10.449877,11.292645 Z" />
+    <path
+       id="rect7139"
+       style="fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.06572,4.4878315 1.2390195,2.2271466 13.805344,19.314948 Z" />
+    <path
+       id="rect7139-0"
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 34.506816,44.681855 49.328546,46.974916 36.799573,29.85971 Z" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:35.586px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#2592b0;fill-opacity:1;stroke:none;stroke-width:0.889647"
+       x="13.393329"
+       y="35.537487"
+       id="text7472"><tspan
+         sodipodi:role="line"
+         id="tspan7470"
+         x="13.393329"
+         y="35.537487"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:35.586px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#2592b0;fill-opacity:1;stroke-width:0.889647">e</tspan></text>
+  </g>
+</svg>

--- a/icons/trigger.svg
+++ b/icons/trigger.svg
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="50mm"
+   height="50mm"
+   viewBox="0 0 50 50"
+   version="1.1"
+   id="svg855"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="trigger.svg">
+  <defs
+     id="defs849" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.1062084"
+     inkscape:cx="105.92986"
+     inkscape:cy="83.944649"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:window-width="1531"
+     inkscape:window-height="1048"
+     inkscape:window-x="2949"
+     inkscape:window-y="346"
+     inkscape:window-maximized="0"
+     units="mm"
+     inkscape:pagecheckerboard="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2210" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata852">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:none">
+    <rect
+       style="display:inline;opacity:1;fill:#3d8037;fill-opacity:0.400538;stroke-width:0.2732;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212"
+       width="75"
+       height="75"
+       x="0.059107598"
+       y="0.091476537"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#3d5238;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9"
+       width="75"
+       height="75"
+       x="75.059105"
+       y="0.091476537"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#905238;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9-3"
+       width="75"
+       height="75"
+       x="75.059105"
+       y="75.091476"
+       ry="5.9678059e-14" />
+    <rect
+       style="display:inline;opacity:1;fill:#9052ac;fill-opacity:0.400538;stroke-width:0.273201;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect2212-9-3-6"
+       width="75"
+       height="75"
+       x="0.059107598"
+       y="75.091476"
+       ry="5.9678059e-14" />
+  </g>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline">
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-9-9-3"
+       width="7.2160378"
+       height="16.068613"
+       x="26.560078"
+       y="33.766804"
+       ry="2.7793363e-14"
+       transform="matrix(0.99999931,0.00117118,0.0018982,0.9999982,0,0)" />
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-9-9-7"
+       width="7.2162161"
+       height="25.378803"
+       x="3.2921932"
+       y="16.329721"
+       ry="4.3896903e-14"
+       transform="matrix(-0.99999899,-0.00142158,0.63979913,0.76854218,0,0)" />
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-9-9-3-6"
+       width="7.2160378"
+       height="16.068613"
+       x="-23.457281"
+       y="33.914227"
+       ry="2.7793363e-14"
+       transform="matrix(-0.99999931,0.00117118,-0.0018982,0.9999982,0,0)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:33.3555px;line-height:1.25;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#2592b0;fill-opacity:1;stroke:none;stroke-width:0.833887"
+       x="14.62644"
+       y="18.011971"
+       id="text7472"><tspan
+         sodipodi:role="line"
+         id="tspan7470"
+         x="14.62644"
+         y="18.011971"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:33.3555px;font-family:Montserrat;-inkscape-font-specification:'Montserrat, Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#2592b0;fill-opacity:1;stroke-width:0.833887">e</tspan></text>
+    <rect
+       style="display:inline;fill:#2592b0;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6836-1-9-9-7-8"
+       width="7.2162161"
+       height="25.378803"
+       x="53.368549"
+       y="16.422348"
+       ry="4.3896903e-14"
+       transform="matrix(0.99999899,-0.00142158,-0.63979913,0.76854218,0,0)" />
+  </g>
+</svg>


### PR DESCRIPTION
# Changes

- :gift: Add icons for Serving and Eventing

/kind documentation

Fixes lack of icons in the project. 

Currently there are no icons available.

Docs and presentations have no standard in diagrams. Icons would help convey concepts and ideas across platforms. 

This [doc](https://docs.google.com/document/d/18iLbEPXSil4XsjKs5WcC_9uK9WYnV2CSXYu4uj8OIVo/edit) describes the icons in detail. 

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
New set of icons have been included for use across documentation, presentations, and IDEs.
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[icons now available for diagrams in docs, this PR does not update docs directly]
```
