### PR TITLE
Add teams for eventing-* approvers

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -801,6 +801,7 @@ orgs:
           eventing-couchdb: write
         members:
         - lberk
+        - lionelvillard
 
       eventing-github Approvers:
         description: Approver group for eventing-github - to be used in CODEOWNERS file
@@ -816,10 +817,10 @@ orgs:
         repo:
           eventing-gitlab: write
         members:
+        - antoineco
         - lberk
         - sebgoa
         - tzununbekov
-        - antoineco
 
       eventing-kafka Approvers:
         description: Approver group for eventing-kafka - to be used in CODEOWNERS file
@@ -827,10 +828,11 @@ orgs:
         repo:
           eventing-kafka: write
         members:
-        - davyodom
-        - travis-minke-sap
-        - phamilton
         - aliok
+        - davyodom
+        - matzew
+        - phamilton
+        - travis-minke-sap
 
       eventing-kafka-broker Approvers:
         description: Approver group for eventing-kafka-broker - to be used in CODEOWNERS file
@@ -839,6 +841,7 @@ orgs:
           eventing-kafka-broker: write
         members:
         - pierDipi
+        - slinkydeveloper
 
       eventing-natss Approvers:
         description: Approver group for eventing-natss - to be used in CODEOWNERS file
@@ -846,6 +849,7 @@ orgs:
         repo:
           eventing-natss: write
         members:
+        - devguyio
 
       eventing-prometheus Approvers:
         description: Approver group for eventing-prometheus - to be used in CODEOWNERS file
@@ -861,6 +865,8 @@ orgs:
         repo:
           eventing-rabbitmq: write
         members:
+        - n3wscott
+        - vaikas
 
       eventing-redis Approvers:
         description: Approver group for eventing-redis - to be used in CODEOWNERS file
@@ -869,6 +875,7 @@ orgs:
           eventing-redis: write
         members:
         - aavarghese
+        - lionelvillard
 
       kn-plugin-admin Approvers:
         description: Approver group for kn-plugin-admin - to be used in CODEOWNERS file

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -247,6 +247,7 @@ orgs:
     - ZhuangYuZY
     - zouyee
     - zrob
+    - zroubalik
     - zyjiaobj
     - 12345lcr
     repos:

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -802,6 +802,14 @@ orgs:
         members:
         - lberk
 
+      eventing-github Approvers:
+        description: Approver group for eventing-github - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-github: write
+        members:
+        - lberk
+
       eventing-gitlab Approvers:
         description: Approver group for eventing-gitlab - to be used in CODEOWNERS file
         privacy: closed
@@ -812,14 +820,6 @@ orgs:
         - sebgoa
         - tzununbekov
         - antoineco
-
-      eventing-github Approvers:
-        description: Approver group for eventing-github - to be used in CODEOWNERS file
-        privacy: closed
-        repo:
-          eventing-github: write
-        members:
-        - lberk
 
       eventing-kafka Approvers:
         description: Approver group for eventing-kafka - to be used in CODEOWNERS file

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -761,6 +761,114 @@ orgs:
         - julz
         - maximilien
 
+      eventing-autoscaler-keda Approvers:
+        description: Approver group for eventing-autoscaler-keda - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-autoscaler-keda: write
+        members:
+        - zroubalik
+
+      eventing-awssqs Approvers:
+        description: Approver group for eventing-awssqs - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-awssqs: write
+        members:
+        - lberk
+
+      eventing-camel Approvers:
+        description: Approver group for eventing-camel - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-camel: write
+        members:
+        - nicolaferraro
+
+      eventing-ceph Approvers:
+        description: Approver group for eventing-ceph - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-ceph: write
+        members:
+        - lberk
+
+      eventing-couchdb Approvers:
+        description: Approver group for eventing-couchdb - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-couchdb: write
+        members:
+        - lberk
+
+      eventing-gitlab Approvers:
+        description: Approver group for eventing-gitlab - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-gitlab: write
+        members:
+        - lberk
+        - sebgoa
+        - tzununbekov
+        - antoineco
+
+      eventing-github Approvers:
+        description: Approver group for eventing-github - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-github: write
+        members:
+        - lberk
+
+      eventing-kafka Approvers:
+        description: Approver group for eventing-kafka - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-kafka: write
+        members:
+        - davyodom
+        - travis-minke-sap
+        - phamilton
+        - aliok
+
+      eventing-kafka-broker Approvers:
+        description: Approver group for eventing-kafka-broker - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-kafka-broker: write
+        members:
+        - pierDipi
+
+      eventing-natss Approvers:
+        description: Approver group for eventing-natss - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-natss: write
+        members:
+
+      eventing-prometheus Approvers:
+        description: Approver group for eventing-prometheus - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-prometheus: write
+        members:
+        - lberk
+
+      eventing-rabbitmq Approvers:
+        description: Approver group for eventing-rabbitmq - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-rabbitmq: write
+        members:
+
+      eventing-redis Approvers:
+        description: Approver group for eventing-redis - to be used in CODEOWNERS file
+        privacy: closed
+        repo:
+          eventing-redis: write
+        members:
+        - aavarghese
+
       kn-plugin-admin Approvers:
         description: Approver group for kn-plugin-admin - to be used in CODEOWNERS file
         privacy: closed


### PR DESCRIPTION
Teams haven't been created yet.
Some teams are empty since currently all members are WG leads. Hopefully this is not causing problems, otherwise I'll add at least a member to the list. 
