### PR TITLE
add roadmap link for UX working group table

### DIFF
--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -64,6 +64,7 @@ The current working groups are:
 - [Productivity](#productivity)
 - [Scaling](#scaling)
 - [Security](#security)
+- [User Experience](user-experience)
   <!-- TODO add charters for each group -->
 
 ## API Core

--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -64,7 +64,7 @@ The current working groups are:
 - [Productivity](#productivity)
 - [Scaling](#scaling)
 - [Security](#security)
-- [User Experience](user-experience)
+- [User Experience](#user-experience)
   <!-- TODO add charters for each group -->
 
 ## API Core

--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -311,6 +311,7 @@ User Experience concerns across Knative components
 | Roadmap                    | [Roadmap](https://github.com/orgs/knative/projects/20)                                                                                                  |
 | Document Folder            | [Folder](https://drive.google.com/drive/folders/1XzZGqV7yHo38d_l7rH1uSIrbQp3JlbBP?usp=sharing)                                                          |
 | Slack Channel              | [#user-experience](https://slack.knative.dev/messages/user-experience)                                                                                  |
+| Github Repository          | [#user-experience](https://github.com/knative/ux)                                                                                                       |
 | Github Team WG leads       | [@knative/ux-wg-leads](https://github.com/orgs/knative/teams/ux-wg-leads/members)                                                                       |
 
 | &nbsp;                                                        | Leads           | Company | Profile                                             |

--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -308,6 +308,7 @@ User Experience concerns across Knative components
 | Community Meeting VC       | See the top of the [Meeting notes](https://docs.google.com/document/d/1NSlGHen5Dh6c2A0LGavGWibddWrlSLV_PbEbMpNjSTU/edit?usp=sharing)                    |
 | Community Meeting Calendar | Thursdays at 8am PST <br>[Calendar](https://calendar.google.com/calendar/embed?src=knative.team_9q83bg07qs5b9rrslp5jor4l6s%40group.calendar.google.com) |
 | Meeting Notes              | [Notes](https://docs.google.com/document/d/1NSlGHen5Dh6c2A0LGavGWibddWrlSLV_PbEbMpNjSTU/edit?usp=sharing)                                               |
+| Roadmap                    | [Roadmap](https://github.com/orgs/knative/projects/20)                                                                                                  |
 | Document Folder            | [Folder](https://drive.google.com/drive/folders/1XzZGqV7yHo38d_l7rH1uSIrbQp3JlbBP?usp=sharing)                                                          |
 | Slack Channel              | [#user-experience](https://slack.knative.dev/messages/user-experience)                                                                                  |
 | Github Team WG leads       | [@knative/ux-wg-leads](https://github.com/orgs/knative/teams/ux-wg-leads/members)                                                                       |


### PR DESCRIPTION

# Changes
Add roadmap link for UX WG

- :gift: Add roadmap link for UX WG

/kind documentation


Related to #490 

