### PR TITLE
Check in initial TOC review schedule

### DIFF
--- a/mechanics/TOC-REVIEW.schedule
+++ b/mechanics/TOC-REVIEW.schedule
@@ -1,0 +1,19 @@
+#@ title: ToC Working Group Update
+#@ duration: 45m
+
+# Start | Group
+2021-03-11T08:30:00-08:00 | Security WG
+# US Daylight savings
+2021-03-18T08:30:00-07:00 | User Experience WG
+2021-03-25T08:30:00-07:00 | Productivity WG
+2021-04-01T08:30:00-07:00 | Client WG
+2021-04-08T08:30:00-07:00 | Sources WG
+2021-04-15T08:30:00-07:00 | Serving API WG
+2021-04-22T08:30:00-07:00 | Scaling WG
+2021-04-29T08:30:00-07:00 | Event Delivery WG
+2021-05-06T08:30:00-07:00 | Operations WG
+2021-05-13T08:30:00-07:00 | Eventing WG
+2021-05-20T08:30:00-07:00 | Docs WG
+2021-05-27T08:30:00-07:00 | Networking WG
+2021-06-03T08:30:00-07:00 | Security WG
+2021-06-10T08:30:00-07:00 | User Experience WG


### PR DESCRIPTION
Rather than keeping the schedule at the top of the Google doc, check it in so we can do automation (starting with https://knative.party/)
