### PR TITLE
Add Ron as an actual org member

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -382,6 +382,7 @@ orgs:
     - rmoe
     - rmorgan
     - rohitagarwalla
+    - ronavn
     - roopakparikh
     - rootfs
     - rosenhouse


### PR DESCRIPTION
See #532 -- it turns out that Ron was being removed from the org and then re-invited because he wasn't in the members list, but was on a team.
