### PR TITLE
Staging a rename of downstream-test-go to actions-downstream-test

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -265,6 +265,12 @@ orgs:
         description: "Repository for sharing org-wide Github metadata and workflow templates."
         has_projects: true
         has_wiki: false
+      actions-downstream-test:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        description: Github Action for Knative to test downstream repos upgradability from upstream repos.
+        has_projects: true
+        has_wiki: false
       actions-kind:
         allow_merge_commit: false
         allow_rebase_merge: false
@@ -588,6 +594,7 @@ orgs:
         repos:
           # All repos should be listed here!
           .github: admin
+          actions-downstream-test: admin
           actions-kind: admin
           async-component: admin
           build-spike: admin
@@ -702,6 +709,7 @@ orgs:
         privacy: closed
         repos:
           .github: write
+          actions-downstream-test: write
           actions-kind: write
           downstream-test-go: write
           kperf: write


### PR DESCRIPTION
I am staging the rename of `actions-downstream-test` to `actions-downstream-test` per https://github.com/knative/community/issues/324#issuecomment-709415206