### PR TITLE
Add groups based on observed usage in knative repos

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -173,12 +173,14 @@ aliases:
   - mdemirhan
   - vagababov
   pkg-controller-reviewers:
+  - dprotaso
   - grantr
   - mattmoor
   - tcnghia
   - vagababov
   - whaught
   pkg-controller-writers:
+  - dprotaso
   - grantr
   - mattmoor
   - tcnghia

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,24 +3,49 @@
 aliases:
   api-core-wg-leads:
   - dprotaso
+  autoscaling-reviewers:
+  - taragu
   autoscaling-wg-leads:
   - markusthoemmes
   - vagababov
+  autoscaling-writers:
+  - julz
+  - markusthoemmes
+  - vagababov
+  - yanweiguo
   channel-wg-leads:
   - matzew
   - slinkydeveloper
+  client-reviewers:
+  - itsmurugappan
   client-wg-leads:
   - navidshaikh
   - rhuss
   client-writers:
+  - dsimansk
+  - maximilien
   - navidshaikh
   - rhuss
   conformance-wg-leads:
   - tayarani
   conformance-writers:
   - tayarani
+  docs-reviewers:
+  - RichardJJG
+  - jonatasbaldin
+  - mpetason
+  - omerbensaadon
+  - snneji
   docs-wg-leads: []
-  docs-writers: []
+  docs-writers:
+  - abrennan89
+  - carieshmarie
+  - richieescarez
+  eventing-reviewers:
+  - aslom
+  - nlopezgi
+  - tayarani
+  - tommyreddad
   eventing-triage:
   - akashrv
   - antoineco
@@ -35,6 +60,7 @@ aliases:
   - vaikas
   eventing-writers:
   - akashrv
+  - aliok
   - antoineco
   - devguyio
   - grantr
@@ -42,6 +68,7 @@ aliases:
   - lionelvillard
   - matzew
   - n3wscott
+  - pierDipi
   - slinkydeveloper
   - vaikas
   - zhongduo
@@ -94,19 +121,83 @@ aliases:
   - knative-prow-releaser-robot
   - knative-prow-robot
   - knative-test-reporter-robot
+  networking-reviewers:
+  - JRBANCEL
+  - ZhiminXiang
+  - andrew-su
+  - arturenault
+  - markusthoemmes
+  - nak3
+  - shashwathi
+  - tcnghia
+  - vagababov
+  - yanweiguo
   networking-wg-leads:
   - ZhiminXiang
   - nak3
   - tcnghia
+  networking-writers:
+  - JRBANCEL
+  - ZhiminXiang
+  - nak3
+  - tcnghia
+  - vagababov
+  operations-reviewers:
+  - Cynocracy
+  - aliok
+  - houshengbo
+  - jcrossley3
+  - markusthoemmes
+  - matzew
+  - n3wscott
+  - trshafer
+  - yu2003w
   operations-wg-leads:
   - houshengbo
   operations-writers:
+  - Cynocracy
+  - aliok
   - houshengbo
+  - jcrossley3
+  - markusthoemmes
+  - matzew
+  - n3wscott
+  - trshafer
+  pkg-configmap-reviewers:
+  - dprotaso
+  - mattmoor
+  - mdemirhan
+  - vagababov
+  pkg-configmap-writers:
+  - dprotaso
+  - mattmoor
+  - mdemirhan
+  - vagababov
+  pkg-controller-reviewers:
+  - grantr
+  - mattmoor
+  - tcnghia
+  - vagababov
+  - whaught
+  pkg-controller-writers:
+  - grantr
+  - mattmoor
+  - tcnghia
+  - vagababov
+  productivity-reviewers:
+  - coryrc
+  - efiturri
+  - evankanderson
+  - peterfeifanchen
+  - steuhs
+  - yt3liu
   productivity-wg-leads:
   - chizhg
   - n3wscott
   productivity-writers:
+  - chaodaiG
   - chizhg
+  - coryrc
   - n3wscott
   security-wg-leads:
   - evankanderson
@@ -114,11 +205,19 @@ aliases:
   security-writers:
   - evankanderson
   - julz
+  serving-observability-reviewers:
+  - mdemirhan
+  - skonto
+  - yanweiguo
+  serving-observability-writers:
+  - mdemirhan
+  - yanweiguo
+  serving-reviewers:
+  - julz
+  - whaught
   serving-writers:
-  - ZhiminXiang
   - dprotaso
   - markusthoemmes
-  - nak3
   - tcnghia
   - vagababov
   source-wg-leads:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -151,7 +151,6 @@ aliases:
   - matzew
   - n3wscott
   - trshafer
-  - yu2003w
   operations-wg-leads:
   - houshengbo
   operations-writers:

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -945,7 +945,6 @@ orgs:
         - matzew
         - n3wscott
         - trshafer
-        - yu2003w
       Operations Writers:
         description: Grants write access to operations-related repositories.
         privacy: closed

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -670,6 +670,32 @@ orgs:
         has_wiki: false
         homepage: https://knative.dev
     teams:
+      Autoscaling Reviewers:
+        description: Receive reviews for autoscaling directories
+        privacy: closed
+        members:
+        - taragu
+      Autoscaling Writers:
+        description: Approvers and write access for autoscaling-related repositories.
+        privacy: closed
+        repos:
+          pkg: write
+          serving: write
+        members:
+        - julz
+        - yanweiguo
+        teams:
+          Autoscaling WG Leads:
+            description: The Working Group leads for Autoscaling
+            members:
+            - vagababov
+            - markusthoemmes
+            privacy: closed
+      Client Reviewers:
+        description: Receive reviews for client directories
+        privacy: closed
+        members:
+        - itsmurugappan
       Client Writers:
         description: Grants write access to client-related repositories.
         privacy: closed
@@ -685,6 +711,9 @@ orgs:
             - navidshaikh
             - rhuss
             privacy: closed
+        members:
+        - maximilien
+        - dsimansk
       Conformance Writers:
         description: Grants write access to conformance-related repositories.
         privacy: closed
@@ -696,6 +725,15 @@ orgs:
             members:
             - tayarani
             privacy: closed
+      Docs Reviewers:
+        description: Receive reviews for docs directories
+        privacy: closed
+        members:
+        - mpetason
+        - jonatasbaldin
+        - omerbensaadon
+        - RichardJJG
+        - snneji
       Docs Writers:
         description: Grants write access to docs-related repositories.
         privacy: closed
@@ -708,6 +746,18 @@ orgs:
             description: The Working Group leads for Docs
             members: []
             privacy: closed
+        members:
+        - abrennan89
+        - carieshmarie
+        - richieescarez
+      Eventing Reviewers:
+        description: Receive reviews for docs directories
+        privacy: closed
+        members:
+        - aslom
+        - nlopezgi
+        - tommyreddad
+        - tayarani
       Eventing Writers:
         description: Grants write access to eventing-related repositories.
         privacy: closed
@@ -749,6 +799,9 @@ orgs:
             - vaikas
             - n3wscott
             privacy: closed
+        members:
+        - pierDipi
+        - aliok
       Knative Admin:
         description: Individuals in the project who are responsible for billing and
           general project administration.
@@ -848,19 +901,106 @@ orgs:
         - n3wscott
         - lionelvillard
         privacy: closed
+      Networking Reviewers:
+        description: Receive reviews for networking directories
+        privacy: closed
+        members:
+        - andrew-su
+        - arturenault
+        - JRBANCEL
+        - markusthoemmes
+        - nak3
+        - shashwathi
+        - tcnghia
+        - vagababov
+        - yanweiguo
+        - ZhiminXiang
+      Networking Writers:
+        description: Approvers and write access for autoscaling-related repositories
+        privacy: closed
+        repos:
+          serving: write
+          pkg: write
+          networking: write
+        members:
+        - JRBANCEL
+        - vagababov
+        teams:
+          Networking WG Leads:
+            description: The Working Group leads for Networking
+            members:
+            - tcnghia
+            - nak3
+            - ZhiminXiang
+            privacy: closed
+      Operations Reviewers:
+        description: Receive reviews for operations directories
+        privacy: closed
+        members:
+        - aliok
+        - Cynocracy
+        - houshengbo
+        - jcrossley3
+        - markusthoemmes
+        - matzew
+        - n3wscott
+        - trshafer
+        - yu2003w
       Operations Writers:
         description: Grants write access to operations-related repositories.
         privacy: closed
         repos:
-          eventing-operator: write
           operator: write
-          serving-operator: write
+        members:
+        - aliok
+        - Cynocracy
+        - jcrossley3
+        - markusthoemmes
+        - matzew
+        - n3wscott
+        - trshafer
         teams:
           Operations WG Leads:
             description: The Working Group leads for Operations
             members:
             - houshengbo
             privacy: closed
+      Pkg Configmap Reviewers:
+        description: Receive reviews for configmap utilities in pkg
+        privacy: closed
+        teams:
+          Pkg Configmap Writers:
+            description: Approvers for configmap utilities in pkg
+            privacy: closed
+            members:
+            - dprotaso
+            - mattmoor
+            - mdemirhan
+            - vagababov
+      Pkg Controller Reviewers:
+        description: Receive reviews for controller utilities in pkg
+        privacy: closed
+        members:
+        - whaught
+        teams:
+          Pkg Controller Writers:
+            description: Approvers for configmap utilities in pkg
+            privacy: closed
+            members:
+            - grantr
+            - mattmoor
+            - tcnghia
+            - vagababov
+      Productivity Reviewers:
+        description: Receive reviews for productivity directories
+        privacy: closed
+        members:
+        - coryrc
+        - efiturri
+        - evankanderson
+        - peterfeifanchen
+        - steuhs
+        - yt3liu
       Productivity Writers:
         description: Grants write access to productivity-related repositories.
         privacy: closed
@@ -869,6 +1009,9 @@ orgs:
           test-infra: write
           hack: write
           release: write
+        members:
+        - chaodaiG
+        - coryrc
         teams:
           Productivity WG Leads:
             description: The Working Group leads for Productivity
@@ -887,6 +1030,24 @@ orgs:
             - julz
         repos:
           release: write
+      Serving Observability Reviewers:
+        description: Receive reviews for serving observability directories
+        privacy: closed
+        members:
+        - skonto
+        teams:
+          Serving Observability Writers:
+            description: Approve serving observability code
+            privacy: closed
+            members:
+            - mdemirhan
+            - yanweiguo
+      Serving Reviewers:
+        description: Receive reviews for serving-api-related directories
+        privacy: closed
+        members:
+        - whaught
+        - julz
       Serving Writers:
         description: Grants write access to serving-related repositories.
         privacy: closed
@@ -896,24 +1057,15 @@ orgs:
           pkg: write
           serving: write
           release: write
+        members:
+        - markusthoemmes
+        - tcnghia
+        - vagababov
         teams:
           API Core WG Leads:
             description: The Working Group leads for Serving API Core
             members:
             - dprotaso
-            privacy: closed
-          Autoscaling WG Leads:
-            description: The Working Group leads for Autoscaling
-            members:
-            - vagababov
-            - markusthoemmes
-            privacy: closed
-          Networking WG Leads:
-            description: The Working Group leads for Networking
-            members:
-            - tcnghia
-            - nak3
-            - ZhiminXiang
             privacy: closed
       UX Writers:
         description: Grants write access to ux related repositories.

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -983,9 +983,10 @@ orgs:
         - whaught
         teams:
           Pkg Controller Writers:
-            description: Approvers for configmap utilities in pkg
+            description: Approvers for controller utilities in pkg
             privacy: closed
             members:
+            - dprotaso
             - grantr
             - mattmoor
             - tcnghia


### PR DESCRIPTION
(PRs incoming shortly for each repo to use the groups defined here.)

Note that I did not preserve _all_ groups that existing in each OWNERS_ALIASES file. I also needed to create several groups, and split up `Serving Writers` into Working Group based groups.

My criteria for creating groups in peribolos was:
1. Associated with an existing WG (e.g. "$FOO Reviewers" for those working to approver for a WG)
2. **Multiple** directories which should have consistent ownership. There were a number of cases where a group was defined in OWNER_ALIASES and then used in only a single OWNERS file, which seems to simply make extra work. I inlined these groups in the per-repo PRs.

Note that I did _not_ try to rationalize much of the existing files, simply to migrate them to OWNERS_ALIASES

Another change which hasn't yet been done is adding in the "release leads" rotation. I expect to do that during this week, but since Markus and I have TOC approvers in most repos, I don't expect this to be a speedbump for 0.22
