### PR TITLE
Add Elekto requirements for 2021 TOC election.

### DIFF
--- a/elections/2021-TOC/election.yaml
+++ b/elections/2021-TOC/election.yaml
@@ -1,0 +1,15 @@
+name: Knative 2021 TOC Election
+organization: Knative
+start_datetime: 2021-04-27 00:00:01
+end_datetime: 2021-05-11 23:59:00
+no_winners: 2
+allow_no_opinion: True
+delete_after: True
+show_candidate_fields:
+  - employer
+election_officers:
+  - geekygirldawn
+  - jberkus
+eligibility: All Knative contributors with more than 50 contributions are eligible to vote
+exception_description: If you should be eligible to vote, and find that you are unable to, please fill out the exceptions form.    Otherwise, contact elections@knative.team.
+exception_due: 2021-05-08 10:00:00

--- a/elections/2021-TOC/election_desc.md
+++ b/elections/2021-TOC/election_desc.md
@@ -1,10 +1,3 @@
----
-title: "Knative TOC Election - 2021 Voters Guide"
-linkTitle: "2021 Voters Guide"
-weight: 30
-type: "docs"
----
-
 # 2021 Voters Guide - Knative TOC Election
 
 ## Purpose

--- a/elections/2021-TOC/template-for-candidates.md
+++ b/elections/2021-TOC/template-for-candidates.md
@@ -1,0 +1,12 @@
+-------------------------------------------------------------
+name: Your Name
+ID: GithubID
+info:
+  - affiliation: Employer or other org affiliation
+-------------------------------------------------------------
+
+Here's a paragraph about my contributions to Knative.
+
+Here's a paragraph about why I'm running.
+
+(Copy this as candidate-yourname.md and create a PR)

--- a/elections/2021-TOC/voters.yaml
+++ b/elections/2021-TOC/voters.yaml
@@ -1,0 +1,2 @@
+eligible_voters:
+  


### PR DESCRIPTION
This is MOST of the requirements for this election to work with Elekto.io.

The voters.yaml is currently empty, and will need to be populated however we're doing that (devstats or cauldron).

We will also need a webhook in this GH repo to notify elekto of changes (like new candidate profiles).

Yes, election_desc is a duplicate of what's in the README.  I'd like to keep it like that for now, because we haven't tried displaying such a long election brief in Elekto before, and it might turn out that I need to shorten it and redirect to the readme.