### PR TITLE
[WIP]Reformatted candidate template 

### DIFF
--- a/elections/2021-TOC/template-for-candidates.md
+++ b/elections/2021-TOC/template-for-candidates.md
@@ -1,9 +1,9 @@
--------------------------------------------------------------
-name: Your Name
-ID: GithubID
-info:
+Name: Your Name
+
+ID: GitHub ID
+
+Info:
   - affiliation: Employer or other org affiliation
--------------------------------------------------------------
 
 Here's a paragraph about my contributions to Knative.
 


### PR DESCRIPTION
The docs builds were interpreting our candidate template as yaml for some reason (likely the --- used as line separators), which seemed to be breaking the docs builds. This [thread on slack](https://knative.slack.com/archives/C9CV04DNJ/p1618356669262100) provides more context.

@bsnchan @grantr @RichieEscarez @jberkus 

