### PR TITLE
Add julz to API Approvers

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -1061,6 +1061,7 @@ orgs:
         - markusthoemmes
         - tcnghia
         - vagababov
+        - julz
         teams:
           API Core WG Leads:
             description: The Working Group leads for Serving API Core


### PR DESCRIPTION
I think this is the right place in peribolos to add myself as API WG approver 🤞. 

from [Requirements](https://github.com/knative/community/blob/main/ROLES.md#requirements-1):

- Reviewer of the codebase for at least 3 months: Reviewing in serving api since [May 2020](https://github.com/knative/serving/pull/7866)

- Primary reviewer for at least 10 substantial PRs to the codebase: 
  - [**34 reviews tagged size/L**](https://github.com/knative/serving/pulls?page=2&q=is%3Apr+reviewed-by%3Ajulz+label%3Aarea%2Fapi+-author%3Ajulz+is%3Aclosed+label%3Asize%2FL)
  -  picking 10 out: https://github.com/knative/serving/pull/11176, https://github.com/knative/serving/pull/10467, https://github.com/knative/serving/pull/11038, https://github.com/knative/serving/pull/9810, https://github.com/knative/serving/pull/10248, https://github.com/knative/serving/pull/10106, https://github.com/knative/serving/pull/8958, https://github.com/knative/serving/pull/8613, https://github.com/knative/serving/pull/9072, https://github.com/knative/serving/pull/7935. 

- Reviewed at least 30 PRs to the codebase: 
  - [**120 Reviews in area/api**](https://github.com/knative/serving/pulls?q=is%3Apr+reviewed-by%3Ajulz+label%3Aarea%2Fapi+-author%3Ajulz+is%3Aclosed) (5 open, 115 closed) in area/api
  - Also [78 merged PRs in serving area/api](https://github.com/knative/serving/pulls?q=is%3Apr+author%3Ajulz+label%3Aarea%2FAPI+is%3Aclosed), including background digest resolution, domain mapping. 

- Nominated by a a WG lead: @dprotaso nominated in TOC update

/assign @dprotaso 