### PR TITLE
Update TOC to reflect changes in election system

### DIFF
--- a/mechanics/TOC.md
+++ b/mechanics/TOC.md
@@ -64,10 +64,8 @@ requirements based on community feedback.
 
 Elections will be held using a time-limited
 [Condorcet](https://en.wikipedia.org/wiki/Condorcet_method) ranking on
-[CIVS](http://civs.cs.cornell.edu/) using the
-[Schulze](https://en.wikipedia.org/wiki/Schulze_method) method. The top
-vote-getters will be elected to the open seats. This is the same process used by
-the Kubernetes project.
+[Elekto](https://elekto.io/). The top vote-getters will be elected to
+the open seats.
 
 ## Election Officers
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

# Changes

This PR amends the TOC charter to represent the current voting system.

For the 2021 TOC election, the voting system has been changed from CIVS to Elekto.

This change was [represented in the 2021 election documentation](https://github.com/knative/community/tree/main/elections/2021-TOC#voting-process), but the TOC charter had not been updated.


/kind documentation
/kind bug
