### PR TITLE
Remove emeritus members from teams

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -167,12 +167,10 @@ aliases:
   pkg-configmap-reviewers:
   - dprotaso
   - mattmoor
-  - mdemirhan
   - vagababov
   pkg-configmap-writers:
   - dprotaso
   - mattmoor
-  - mdemirhan
   - vagababov
   pkg-controller-reviewers:
   - dprotaso
@@ -209,11 +207,9 @@ aliases:
   - evankanderson
   - julz
   serving-observability-reviewers:
-  - mdemirhan
   - skonto
   - yanweiguo
   serving-observability-writers:
-  - mdemirhan
   - yanweiguo
   serving-reviewers:
   - julz

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -977,7 +977,6 @@ orgs:
             members:
             - dprotaso
             - mattmoor
-            - mdemirhan
             - vagababov
       Pkg Controller Reviewers:
         description: Receive reviews for controller utilities in pkg
@@ -1043,7 +1042,6 @@ orgs:
             description: Approve serving observability code
             privacy: closed
             members:
-            - mdemirhan
             - yanweiguo
       Serving Reviewers:
         description: Receive reviews for serving-api-related directories


### PR DESCRIPTION
mdemirhan@ is no longer in the Knative org; removing him from teams to avoid OWNERS failures.
