### PR TITLE
Add kntaive-prow-updater-robot to knative and knative-sandbox org

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -139,6 +139,7 @@ orgs:
     - knative-automation
     - knative-metrics-robot
     - knative-prow-releaser-robot
+    - knative-prow-updater-robot
     - knative-test-reporter-robot
     - krumts
     - kthakar1990
@@ -633,6 +634,7 @@ orgs:
             members:
             - knative-prow-robot
             - knative-prow-releaser-robot
+            - knative-prow-updater-robot
             - knative-test-reporter-robot
             privacy: closed
           Steering Committee:

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -272,6 +272,7 @@ orgs:
     - knative-automation
     - knative-metrics-robot
     - knative-prow-releaser-robot
+    - knative-prow-updater-robot
     - knative-test-reporter-robot
     - komestmus
     - krumts
@@ -841,6 +842,7 @@ orgs:
             members:
             - knative-prow-robot
             - knative-prow-releaser-robot
+            - knative-prow-updater-robot
             - knative-test-reporter-robot
             privacy: closed
           Steering Committee:


### PR DESCRIPTION
This is required to get https://prow.knative.dev/?job=ci-knative-prow-jobs-syncer and https://prow.knative.dev/?job=ci-knative-prow-auto-bumper-for-auto-deploy pass.