### PR TITLE
Remove grantr from TOC and Eventing WG lead

### DIFF
--- a/TECH-OVERSIGHT-COMMITTEE.md
+++ b/TECH-OVERSIGHT-COMMITTEE.md
@@ -95,7 +95,6 @@ The current members of the TOC are shown below.
 | &nbsp;                                                         | Member         | Company | Profile                                              | Term Start | Term End |
 | -------------------------------------------------------------- | -------------- | ------- | ---------------------------------------------------- | ---------- | --------
 | <img width="30px" src="https://github.com/evankanderson.png">  | Evan Anderson  | VMware  | [@evankanderson](https://github.com/evankanderson)   | Bootstrap  | 2021     |
-| <img width="30px" src="https://github.com/grantr.png">         | Grant Rodgers  | Google  | [@grantr](https://github.com/grantr)                 | 2020-06-09 | 2022     |
 | <img width="30px" src="https://github.com/markusthoemmes.png"> | Markus Thömmes | Red Hat | [@markusthoemmes](https://github.com/markusthoemmes) | 2020-06-09 | 2022     |
 | <img width="30px" src="https://github.com/rhuss.png">          | Roland Huß     | Red Hat | [@rhuss](https://github.com/rhuss)                   | 2021-02-16 | 2022     |
 

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -15,7 +15,6 @@ orgs:
     - evankanderson
     - google-admin
     - googlebot
-    - grantr
     - knative-prow-robot
     - markusthoemmes
     - mbehrendt
@@ -570,7 +569,6 @@ orgs:
             description: The Working Group leads for Eventing
             members:
             - devguyio
-            - grantr
             - lionelvillard
             - vaikas
             privacy: closed
@@ -649,7 +647,6 @@ orgs:
           Technical Oversight Committee:
             description: Members of the Knative Technical Oversight Committee (TOC)
             maintainers:
-            - grantr
             - rhuss
             - markusthoemmes
             - evankanderson
@@ -666,7 +663,6 @@ orgs:
           manipulate milestones: https://github.com/knative/test-infra/blob/64615f92c4ebdd4e4423015ffc0db45877660a0d/ci/prow/plugins.yaml#L49'
         privacy: closed
         maintainers:
-        - grantr
         - rhuss
         - markusthoemmes
         - evankanderson
@@ -786,7 +782,6 @@ orgs:
         - matzew
         - lionelvillard
         - vaikas
-        - grantr
 
       discovery Approvers:
         description: Approver group for discovery - to be used in CODEOWNERS file

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -12,7 +12,6 @@ orgs:
     - evankanderson
     - google-admin
     - googlebot
-    - grantr
     - knative-prow-robot
     - markusthoemmes
     - mbehrendt
@@ -793,7 +792,6 @@ orgs:
             description: The Working Group leads for Eventing
             members:
             - devguyio
-            - grantr
             - lionelvillard
             - vaikas
             privacy: closed
@@ -864,7 +862,6 @@ orgs:
           Technical Oversight Committee:
             description: Members of the Knative Technical Oversight Committee (TOC)
             maintainers:
-            - grantr
             - rhuss
             - markusthoemmes
             - evankanderson
@@ -880,7 +877,6 @@ orgs:
         description: 'DO NOT RENAME - this group is used by Prow to control who can manipulate
           milestones: https://github.com/knative/test-infra/blob/64615f92c4ebdd4e4423015ffc0db45877660a0d/ci/prow/plugins.yaml#L49'
         maintainers:
-        - grantr
         - rhuss
         - markusthoemmes
         - evankanderson
@@ -991,7 +987,6 @@ orgs:
             privacy: closed
             members:
             - dprotaso
-            - grantr
             - mattmoor
             - tcnghia
             - vagababov

--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -153,7 +153,6 @@ Event sources, bindings, FaaS framework, and orchestration
 | ------------------------------------------------------------- | -------------------------- | ------- | ------------------------------------------------- |
 | <img width="30px" src="https://github.com/vaikas.png">        | Ville Aikas (Technical)    | VMware  | [vaikas](https://github.com/vaikas)               |
 | <img width="30px" src="https://github.com/lionelvillard.png"> | Lionel Villard (Technical) | IBM     | [lionelvillard](https://github.com/lionelvillard) |
-| <img width="30px" src="https://github.com/grantr.png">        | Grant Rodgers (Technical)  | Google  | [grantr](https://github.com/grantr)               |
 | <img width="30px" src="https://github.com/devguyio.png">      | Ahmed Abdalla (Execution)  | Red Hat | [devguyio](https://github.com/devguyio)           |
 
 ## Event Delivery


### PR DESCRIPTION
[Voluntarily stepped down 2021-05-07](https://groups.google.com/g/knative-dev/c/o9mk87tS4zU/m/hamAENH_AgAJ). 