### PR TITLE
Add results of 2021 TOC election to Elekto App.

### DIFF
--- a/elections/2021-TOC/results.md
+++ b/elections/2021-TOC/results.md
@@ -1,0 +1,19 @@
+## 2021 TOC Member Election Results
+
+Thank you to everyone who took the time to vote in the election! We are delighted to announce that Evan Anderson is our newly reelected TOC member. Please take a moment to congratulate him.
+
+Regarding the 2nd seat:
+
+Unfortunately, Julian Friedman (aka Julz, who works at IBM) had enough votes, but we already have 2 people from Red Hat, which makes Julz ineligible because there can only be a maximum of 2 seats held by employees from the same organization (or conglomerate, in the case of companies owning each other)[2].
+
+David Protasowski and Scott Nichols were tied, so we need to have a run-off election for the second seat.
+
+I’m sure that many of you saw Grant’s announcement about stepping down from the TOC, so we have one extra TOC vacancy. Unfortunately, because of the company limit, we cannot fill this additional seat from this election because it would put either VMware or Red Hat / IBM over the company limit. This means that we will need to run a special election to fill this vacancy, so if you are regretting not running in this election, you will have another chance! 
+
+We’ll be announcing the details for the special election and the run-off election soon.
+
+Cheers,
+
+Dawn Foster and Josh Berkus
+
+TOC Election Officers


### PR DESCRIPTION
Adds a Results page for the 2021 TOC election.

@bsnchan @geekygirldawn  please approve.
