### PR TITLE
Revisit rules around what happens when a TOC member resigns

### DIFF
--- a/mechanics/TOC.md
+++ b/mechanics/TOC.md
@@ -32,10 +32,6 @@ with at least 3 months tenure are eligible to stand for election. Candidates may
 self-nominate or be nominated by another eligible member. The approximate time
 commitment of a TOC member is around 8 hours per week.
 
-Please note that vendor or organization limits do not restrict candidate eligibility.
-We encourage all interested candidates in running as there may be occurrences where a TOC member
-steps down and is back-filled by the candidate with the next most votes from the previous election.
-
 # Voter Eligibility
 
 Anyone who has at least 50 contributions in the last 12 months is eligible to
@@ -74,16 +70,10 @@ committee elections.
 
 ## Vacancies
 
-In the event of a resignation or other loss of an elected TOC member, the
-candidate with the next most votes from the previous election will be offered
-the seat. This process will continue until the seat is filled.
-
-In case this fails to fill the seat, a special election for that position will
-be held as soon as possible. Eligible voters from the most recent election will
-vote in the special election (ie: eligibility will not be redetermined at the
-time of the special election). Any replacement TOC member will serve out the
-remainder of the term for the person they are replacing, regardless of the
-length of that remainder.
+In the event of a resignation or other loss of an elected TOC member, a special
+election for that position will be held as soon as possible. Any replacement TOC
+member will serve out the remainder of the term for the person they are replacing,
+regardless of the length of that remainder.
 
 ---
 

--- a/mechanics/TOC.md
+++ b/mechanics/TOC.md
@@ -70,23 +70,23 @@ committee elections.
 
 ## Vacancies
 
-In the event of a resignation or other loss of an elected TOC member with more
-than three months left until the next regular annual election, the candidate
-with the next most votes from the previous annual election will be offered the
-seat. If the seat cannot be filled from the previous annual election, the
-candidate with the next most votes from the most recent special election will
-be offered the seat. This process will continue until the seat is filled.
+In the event of a resignation or other loss of an elected TOC member with less
+than three months left until the next regular annual election, the Steering
+Committee shall appoint a qualified contributor to fill that TOC seat until
+that election.
+
+Otherwise the candidate with the next most votes from the previous annual
+election will be offered the seat. If the seat cannot be filled from the
+previous annual election, the candidate with the next most votes from the most
+recent special election will be offered the seat. This process will continue
+until the seat is filled.
 
 In case this fails to fill the seat, a special election for that position will
 be held as soon as possible. Eligible voters from the most recent election will
 vote in the special election (ie: eligibility will not be redetermined at the
-time of the special election). Any replacement TOC member will serve out the
-remainder of the term for the person they are replacing, regardless of the
-length of that remainder.
-
-In the event that a TOC seat becomes available with three months or less left
-until the next regular annual election, the Steering Committee shall appoint a
-qualified contributor to fill that TOC seat until that election.
+time of the special election). Any elected replacement TOC member will serve
+out the remainder of the term for the person they are replacing, regardless of
+the length of that remainder.
 
 ---
 

--- a/mechanics/TOC.md
+++ b/mechanics/TOC.md
@@ -70,10 +70,23 @@ committee elections.
 
 ## Vacancies
 
-In the event of a resignation or other loss of an elected TOC member, a special
-election for that position will be held as soon as possible. Any replacement TOC
-member will serve out the remainder of the term for the person they are replacing,
-regardless of the length of that remainder.
+In the event of a resignation or other loss of an elected TOC member with more
+than three months left until the next regular annual election, the candidate
+with the next most votes from the previous annual election will be offered the
+seat. If the seat cannot be filled from the previous annual election, the
+candidate with the next most votes from the most recent special election will
+be offered the seat. This process will continue until the seat is filled.
+
+In case this fails to fill the seat, a special election for that position will
+be held as soon as possible. Eligible voters from the most recent election will
+vote in the special election (ie: eligibility will not be redetermined at the
+time of the special election). Any replacement TOC member will serve out the
+remainder of the term for the person they are replacing, regardless of the
+length of that remainder.
+
+In the event that a TOC seat becomes available with three months or less left
+until the next regular annual election, the Steering Committee shall appoint a
+qualified contributor to fill that TOC seat until that election.
 
 ---
 


### PR DESCRIPTION
The current situation is silly :). Because, in the event of a TOC member resigning or leaving, the next in line from the previous election is used, folks are encouraged to run in elections for seats that - due to vendor limits - aren’t available to them, just for purposes of vacancies that may arise during the year. This year that has become even, frankly, sillier since an extra resignation has meant two such elections will be held in quick succession.

The current mechanic likely made sense when there were more independent vendors in the project, since in that case the situation was substantially less likely to arise. Now it seems like we'll quite commonly (possibly every election, unless the balance of contributions substantially changes, given the make-up of upcoming vacancies means all IBM/RH vacancies and then all VMware vacancies happen on alternate years) have many candidates that are ineligible, unless we change this rule (and/or the handling of vendor limits).

We can remove the need for people to run for seats that aren’t available by simply holding a special election (rather than using the previous results) in the event a seat does become available. This will avoid encouraging us to waste folk’s time and (frankly) emotional energy when a seat isn’t available, and would in any event (IMO, anyway) be a better and fairer way to fill any vacancies, especially if they arise later in the year.