### PR TITLE
Adding eric-sap as eventing-kafka approver

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -87,6 +87,7 @@ orgs:
     - eobrain
     - ericbottard
     - ericlem
+    - eric-sap
     - fabolive
     - fallback-notification-blocker
     - fj
@@ -860,6 +861,7 @@ orgs:
         - aliok
         - davyodom
         - devguyio
+        - eric-sap
         - lberk
         - matzew
         - phamilton


### PR DESCRIPTION
I would like to add `eric-sap` as an eventing-kafka approver.  @matzew has also indicated his agreement with this ; )

I'm not up-to-speed as to whether this is the correct config and whether anything else might be required - please advise if so - thanks!
