### PR TITLE
Updated Elekto results page with the final TOC election results

### DIFF
--- a/elections/2021-TOC/results.md
+++ b/elections/2021-TOC/results.md
@@ -1,19 +1,18 @@
 ## 2021 TOC Member Election Results
 
-Thank you to everyone who took the time to vote in the election! We are delighted to announce that Evan Anderson is our newly reelected TOC member. Please take a moment to congratulate him.
+Thank you to everyone who took the time to vote in the Technical 
+Oversight Committee (TOC) election! 
 
-Regarding the 2nd seat:
+We are happy to announce that Julian Friedman (aka Julz), David Protasowski,
+and Evan Anderson are our newly elected [TOC members](https://github.com/knative/community/blob/main/TECH-OVERSIGHT-COMMITTEE.md)
+for 2021. Please take a moment to congratulate them.
 
-Unfortunately, Julian Friedman (aka Julz, who works at IBM) had enough votes, but we already have 2 people from Red Hat, which makes Julz ineligible because there can only be a maximum of 2 seats held by employees from the same organization (or conglomerate, in the case of companies owning each other)[2].
-
-David Protasowski and Scott Nichols were tied, so we need to have a run-off election for the second seat.
-
-I’m sure that many of you saw Grant’s announcement about stepping down from the TOC, so we have one extra TOC vacancy. Unfortunately, because of the company limit, we cannot fill this additional seat from this election because it would put either VMware or Red Hat / IBM over the company limit. This means that we will need to run a special election to fill this vacancy, so if you are regretting not running in this election, you will have another chance! 
-
-We’ll be announcing the details for the special election and the run-off election soon.
+Both Julz and Evan will serve 2 year terms while David will serve the remainder
+of Grant’s term ending in 2022, since Grant recently 
+[stepped down from the TOC](https://groups.google.com/g/knative-dev/c/o9mk87tS4zU/m/hamAENH_AgAJ).
 
 Cheers,
-
 Dawn Foster and Josh Berkus
-
 TOC Election Officers
+To contact us, email elections@knative.team
+


### PR DESCRIPTION
Updated Elekto results page with the final TOC election results, since we are not having a runoff.

@jberkus Can you have a quick look to make sure that this looks good to you and doesn't break anything in Elekto before we have someone from steering approve it?

/hold
