### PR TITLE
Add bbtong to the members list

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -46,6 +46,7 @@ orgs:
     - aslom
     - balopat
     - bbrowning
+    - bbtong
     - bcle
     - beemarie
     - benmoss

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -68,6 +68,7 @@ orgs:
     - ayj
     - balopat
     - bbrowning
+    - bbtong
     - bcle
     - beemarie
     - bendory


### PR DESCRIPTION
Add `bbtong` to the Knative members list, as part of VMware CNR Connectivity to eventually submit to Knative feature work.

I signed the VMware<>Google internal CCLA, as was advised to do that, but (VMware someone?) let me know if I still have to sign Google's CLA beyond it.