### PR TITLE
Add kn-plugin-func entries for peribolos

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -400,6 +400,12 @@ orgs:
         description: Kn plugin for sending events to Knative sinks.
         has_projects: true
         has_wiki: false
+      kn-plugin-func:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        description: Kn plugin for opinionated function development.
+        has_projects: true
+        has_wiki: false
       kn-plugin-migration:
         allow_merge_commit: false
         allow_rebase_merge: false
@@ -525,6 +531,7 @@ orgs:
           kn-plugin-admin: write
           kn-plugin-diag: write
           kn-plugin-event: write
+          kn-plugin-func: write
           kn-plugin-migration: write
           kn-plugin-quickstart: write
           kn-plugin-sample: write
@@ -620,6 +627,7 @@ orgs:
           kn-plugin-admin: admin
           kn-plugin-diag: admin
           kn-plugin-event: admin
+          kn-plugin-func: admin
           kn-plugin-migration: admin
           kn-plugin-quickstart: admin
           kn-plugin-sample: admin


### PR DESCRIPTION

# Changes

- :gift: Add kn-plugin-func entries for peribolos

/kind enhancement

Related: https://github.com/knative/community/issues/613

**Release Note**

```release-note
Adds the kn-plugin-func repository for the `kn` CLI client, providing an opinionated and simple function development user experience for Knative.
```

**Docs**

It is unclear to me what needs to be done with docs for this change.

```docs

```

Signed-off-by: Lance Ball <lball@redhat.com>
