### PR TITLE
Fix for @dolfolife's Github name update

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -55,8 +55,8 @@ orgs:
     - antoineco
     - apolito
     - arghya88
-    - arturenault
     - ariel-bentu
+    - arturenault
     - aryann
     - asaksena
     - asciimike
@@ -70,7 +70,6 @@ orgs:
     - bbrowning
     - bbtong
     - bcle
-    - bvennam
     - bendory
     - Benjamintf1
     - benmoss
@@ -95,6 +94,7 @@ orgs:
     - bstick12
     - bszwej
     - btardell
+    - bvennam
     - bwmcadams
     - capri-xiyue
     - cardil
@@ -112,8 +112,8 @@ orgs:
     - cooperneil
     - coryrc
     - cppforlife
-    - craigbox
     - cr22rc
+    - craigbox
     - csantanapr
     - cscheiber
     - Cynocracy
@@ -142,6 +142,7 @@ orgs:
     - dgrove-oss
     - dieucao
     - dlorenc
+    - dolfolife
     - dosire
     - droot
     - dsimansk
@@ -382,13 +383,12 @@ orgs:
     - rbuskens
     - rettori
     - rfranzke
+    - RichardJJG
     - RichieEscarez
     - richterdavid
-    - RichardJJG
     - ridruejo
     - rmoe
     - rmorgan
-    - rodolfo2488
     - rohitagarwalla
     - ronavn
     - roopakparikh


### PR DESCRIPTION
As per title. This tripped the nightly peribolos run.

Also sorted all names again.