### PR TITLE
add @snneji as approver/docs-writters

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -762,6 +762,7 @@ orgs:
         - abrennan89
         - carieshmarie
         - richieescarez
+        - snneji
       Eventing Reviewers:
         description: Receive reviews for docs directories
         privacy: closed


### PR DESCRIPTION
This PR is to promote @snneji to approver for docs repo

@snneji  as far as I'm concerned it meets the [approver requirements](https://knative.dev/community/contributing/roles/#requirements-1)

Examples of contributions:
- Discussions on Slack
- Discussions and attendance on working group weekly meetings
- Review PRs
- Opening issues and initiate roadmap for docs changes
- Content contributions [PRs](https://github.com/knative/docs/pulls?q=is%3Apr+author%3Asnneji+)

/assign @omerbensaadon 
/assign @julz 