### PR TITLE
Add RichardJJG as approver/docs-writter

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -39,9 +39,11 @@ aliases:
   - snneji
   docs-wg-leads: []
   docs-writers:
+  - RichardJJG
   - abrennan89
   - carieshmarie
   - richieescarez
+  - snneji
   eventing-reviewers:
   - aslom
   - tayarani
@@ -202,6 +204,7 @@ aliases:
   - yanweiguo
   serving-reviewers:
   - julz
+  - psschwei
   - whaught
   serving-writers:
   - dprotaso

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -763,6 +763,7 @@ orgs:
         - carieshmarie
         - richieescarez
         - snneji
+        - RichardJJG
       Eventing Reviewers:
         description: Receive reviews for docs directories
         privacy: closed


### PR DESCRIPTION
This PR is to promote @RichardJJG  to the approver for docs repo

@RichardJJG as far as I'm concerned it meets the [approver requirements](https://knative.dev/community/contributing/roles/#requirements-1)

Examples of contributions:
- Discussions on Slack
- Discussions and attendance on working group weekly meetings
- Review PRs
- Opening issues and start initiative of content templates
- Content contributions [PRs](https://github.com/knative/docs/pulls?q=is%3Apr+author%3ARichardJJG+)

/assign @omerbensaadon 
/assign @julz 