### PR TITLE
Drop last occurrence of peribolos test repo

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -658,7 +658,6 @@ orgs:
           reconciler-test: admin
           sample-controller: admin
           sample-source: admin
-          will-peribolos-delete-this: admin
           wg-repository: admin
         teams:
           Knative Robots:


### PR DESCRIPTION
As per title. This currently fails the peribolos jobs. See https://prow.knative.dev/view/gs/knative-prow/logs/post-knative-sandbox-peribolos/1420676713062338560