### PR TITLE
Add Travis and Eric from SAP to control-protocol approvers.

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -816,8 +816,10 @@ orgs:
           control-protocol: write
         members:
         - devguyio
+        - eric-sap
         - matzew
         - lionelvillard
+        - travis-minke-sap
         - vaikas
 
       discovery Approvers:


### PR DESCRIPTION
# Changes
- 🎁   Added travis-minke-sap and eric-sap as approvers to the control-protocol sandbox project.

/kind cleanup

Now that Francesco has left the Knative project, Eric and I are probably the primary consumers of the control-protocol and it would be good for us to be able to help maintain it, etc...
