### PR TITLE
Fix generated group names that contain numbers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,6 +5,7 @@ aliases:
   api-core-wg-leads:
   - dprotaso
   autoscaling-reviewers:
+  - psschwei
   - taragu
   autoscaling-wg-leads:
   - markusthoemmes
@@ -53,7 +54,6 @@ aliases:
   - akashrv
   - antoineco
   - lberk
-  - n3wscott
   eventing-wg-leads:
   - devguyio
   - lionelvillard
@@ -65,7 +65,6 @@ aliases:
   - lberk
   - lionelvillard
   - matzew
-  - n3wscott
   - pierDipi
   - vaikas
   knative-admin:
@@ -144,7 +143,6 @@ aliases:
   - jcrossley3
   - markusthoemmes
   - matzew
-  - n3wscott
   - trshafer
   operations-wg-leads:
   - houshengbo
@@ -155,7 +153,6 @@ aliases:
   - jcrossley3
   - markusthoemmes
   - matzew
-  - n3wscott
   - trshafer
   pkg-configmap-reviewers:
   - dprotaso
@@ -214,7 +211,6 @@ aliases:
   - vagababov
   source-wg-leads:
   - lionelvillard
-  - n3wscott
   steering-committee:
   - bsnchan
   - mbehrendt

--- a/knative-sandbox-OWNERS_ALIASES
+++ b/knative-sandbox-OWNERS_ALIASES
@@ -67,13 +67,15 @@ aliases:
   - pierDipi
   eventing-kafka-mtsource-approvers:
   - steven0711dong
+  eventing-kogito-approvers:
+  - ricardozanini
   eventing-natss-approvers:
   - devguyio
   - zhaojizhuang
   eventing-prometheus-approvers:
   - lberk
   eventing-rabbitmq-approvers:
-  - n3wscott
+  - benmoss
   - sbawaska
   - vaikas
   eventing-redis-approvers:
@@ -86,7 +88,6 @@ aliases:
   - devguyio
   - lionelvillard
   - matzew
-  - n3wscott
   homebrew-kn-plugins-approvers:
   - dsimansk
   - maximilien
@@ -184,9 +185,9 @@ aliases:
   - ZhiminXiang
   net-contour-approvers:
   - dprotaso
-  net-http---approvers:
+  net-http01-approvers:
   - tcnghia
-  net-ingressv--approvers:
+  net-ingressv2-approvers:
   - markusthoemmes
   - nak3
   net-istio-approvers:
@@ -226,7 +227,6 @@ aliases:
   - vagababov
   source-wg-leads:
   - lionelvillard
-  - n3wscott
   steering-committee:
   - bsnchan
   - mbehrendt

--- a/mechanics/tools/gen-aliases/main.go
+++ b/mechanics/tools/gen-aliases/main.go
@@ -43,6 +43,9 @@ func main() {
 		if r >= 'a' && r <= 'z' {
 			return r
 		}
+		if r >= '0' && r <= '9' {
+			return r
+		}
 		return '-'
 	}
 	for _, team := range expandTeams(cfg.Orgs[org].Teams) {


### PR DESCRIPTION
Noticed by @mattmoor, thanks!

Rerun autogen.

/assign @pmorie
