### PR TITLE
Removes bsnchan from steering

### DIFF
--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -94,7 +94,6 @@ first name):
 | &nbsp;                                                         | Member           | Organization | Profile                                              | Term Start | Term End |
 | -------------------------------------------------------------- | ---------------- | ------------ | ---------------------------------------------------- | ---------- | --------
 | <img width="30px" src="https://github.com/thisisnotapril.png"> | April Kyle Nassi | Google       | [@thisisnotapril](https://github.com/thisisnotapril) | Bootstrap  | 2021     |
-| <img width="30px" src="https://github.com/bsnchan.png">        | Brenda Chan      | VMware       | [@bsnchan](https://github.com/bsnchan)               | Bootstrap  | 2021     |
 | <img width="30px" src="https://github.com/mbehrendt.png">      | Michael Behrendt | IBM          | [@mbehrendt](https://github.com/mbehrendt)           | Bootstrap  | 2021     |
 | <img width="30px" src="https://github.com/pmorie.png">         | Paul Morie       | Independent  | [@pmorie](https://github.com/pmorie)                 | 2020-12-11 | 2022     |
 | <img width="30px" src="https://github.com/vaikas.png">         | Ville Aikas      | VMware       | [@vaikas](https://github.com/vaikas)                 | 2020-12-11 | 2022     |


### PR DESCRIPTION
Going on leave :'( - It's been a blast!

I suspect SC will leave the seat empty until the next steering elections in early October so the seat will remain empty for the timebeing.