### PR TITLE
Rotate in new release leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -69,7 +69,7 @@ aliases:
   - pierDipi
   - vaikas
   knative-admin:
-  - ZhiminXiang
+  - bmo
   - bsnchan
   - dprotaso
   - duglin
@@ -87,9 +87,33 @@ aliases:
   - spencerdillard
   - thisisnotapril
   - vaikas
-  knative-release-leads:
+  knative-milestone-maintainers:
+  - ImJasonH
   - ZhiminXiang
+  - andrew-su
+  - aslom
+  - chaodaiG
+  - chizhg
+  - csantanapr
+  - dprotaso
   - evankanderson
+  - igsong
+  - julz
+  - lionelvillard
+  - markusthoemmes
+  - matzew
+  - n3wscott
+  - nak3
+  - navidshaikh
+  - rhuss
+  - shashwathi
+  - tanzeeb
+  - tcnghia
+  - vagababov
+  - vaikas
+  knative-release-leads:
+  - bmo
+  - julz
   knative-robots:
   - knative-prow-releaser-robot
   - knative-prow-robot

--- a/knative-sandbox-OWNERS_ALIASES
+++ b/knative-sandbox-OWNERS_ALIASES
@@ -19,6 +19,10 @@ aliases:
   - dsimansk
   - navidshaikh
   - rhuss
+  container-freezer-approvers:
+  - julz
+  - markusthoemmes
+  - psschwei
   control-protocol-approvers:
   - devguyio
   - eric-sap
@@ -142,7 +146,7 @@ aliases:
   - nicolaferraro
   - rhuss
   knative-admin:
-  - ZhiminXiang
+  - bmo
   - bsnchan
   - dprotaso
   - evankanderson
@@ -157,9 +161,31 @@ aliases:
   - rhuss
   - thisisnotapril
   - vaikas
-  knative-release-leads:
+  knative-milestone-maintainers:
   - ZhiminXiang
+  - akashrv
+  - aslom
+  - chaodaiG
+  - csantanapr
+  - dprotaso
   - evankanderson
+  - josephburnett
+  - julz
+  - k4leung4
+  - lionelvillard
+  - markusthoemmes
+  - matzew
+  - mikehelmick
+  - n3wscott
+  - nak3
+  - navidshaikh
+  - rhuss
+  - tcnghia
+  - vagababov
+  - vaikas
+  knative-release-leads:
+  - bmo
+  - julz
   knative-robots:
   - knative-prow-releaser-robot
   - knative-prow-robot

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -722,8 +722,8 @@ orgs:
           Knative Release Leads:
             description: Active member of the Knative Release Leads rotation.
             maintainers:
-            - ZhiminXiang
-            - evankanderson
+            - julz
+            - bmo
       Knative Milestone Maintainers:
         description: 'DO NOT RENAME - this group is used by Prow to control who can
           manipulate milestones: https://github.com/knative/test-infra/blob/64615f92c4ebdd4e4423015ffc0db45877660a0d/ci/prow/plugins.yaml#L49'

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -883,8 +883,8 @@ orgs:
           Knative Release Leads:
             description: Active member of the Knative Release Leads rotation.
             maintainers:
-            - ZhiminXiang
-            - evankanderson
+            - julz
+            - bmo
       Knative Milestone Maintainers:
         description: 'DO NOT RENAME - this group is used by Prow to control who can manipulate
           milestones: https://github.com/knative/test-infra/blob/64615f92c4ebdd4e4423015ffc0db45877660a0d/ci/prow/plugins.yaml#L49'


### PR DESCRIPTION
Per https://github.com/knative/release, @julz and @bmo will be the release leads for the 2021-11-02 release, tentatively named 0.27.

/assign @julz @bmo
/assign @pmorie
