### PR TITLE
Regenerate owner aliases to be up-to-date

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -69,7 +69,7 @@ aliases:
   - pierDipi
   - vaikas
   knative-admin:
-  - ZhiminXiang
+  - benmoss
   - bsnchan
   - dprotaso
   - duglin
@@ -84,12 +84,38 @@ aliases:
   - omerbensaadon
   - pmorie
   - rhuss
+  - salaboy
   - spencerdillard
   - thisisnotapril
   - vaikas
-  knative-release-leads:
+  knative-milestone-maintainers:
+  - ImJasonH
   - ZhiminXiang
+  - andrew-su
+  - aslom
+  - chaodaiG
+  - chizhg
+  - csantanapr
+  - dprotaso
   - evankanderson
+  - igsong
+  - julz
+  - lionelvillard
+  - markusthoemmes
+  - matzew
+  - n3wscott
+  - nak3
+  - navidshaikh
+  - rhuss
+  - shashwathi
+  - tanzeeb
+  - tcnghia
+  - vagababov
+  - vaikas
+  knative-release-leads:
+  - benmoss
+  - julz
+  - salaboy
   knative-robots:
   - knative-prow-releaser-robot
   - knative-prow-robot
@@ -100,6 +126,7 @@ aliases:
   - ZhiminXiang
   - andrew-su
   - arturenault
+  - carlisia
   - markusthoemmes
   - nak3
   - shashwathi
@@ -157,6 +184,7 @@ aliases:
   - evankanderson
   - gerardo-lc
   - joshua-bone
+  - kvmware
   - steuhs
   productivity-wg-leads:
   - chizhg
@@ -178,7 +206,9 @@ aliases:
   serving-observability-writers:
   - yanweiguo
   serving-reviewers:
+  - carlisia
   - julz
+  - nealhu
   - psschwei
   - whaught
   serving-writers:

--- a/knative-sandbox-OWNERS_ALIASES
+++ b/knative-sandbox-OWNERS_ALIASES
@@ -19,6 +19,10 @@ aliases:
   - dsimansk
   - navidshaikh
   - rhuss
+  container-freezer-approvers:
+  - julz
+  - markusthoemmes
+  - psschwei
   control-protocol-approvers:
   - devguyio
   - eric-sap
@@ -37,18 +41,23 @@ aliases:
   - zroubalik
   eventing-awssqs-approvers:
   - lberk
+  - matzew
   eventing-camel-approvers:
   - nicolaferraro
   eventing-ceph-approvers:
   - lberk
+  - matzew
   eventing-couchdb-approvers:
   - lberk
   - lionelvillard
+  - matzew
   eventing-github-approvers:
   - lberk
+  - matzew
   eventing-gitlab-approvers:
   - antoineco
   - lberk
+  - matzew
   - sebgoa
   - tzununbekov
   eventing-kafka-approvers:
@@ -83,6 +92,7 @@ aliases:
   - zhaojizhuang
   eventing-prometheus-approvers:
   - lberk
+  - matzew
   eventing-rabbitmq-approvers:
   - benmoss
   - sbawaska
@@ -91,6 +101,7 @@ aliases:
   eventing-redis-approvers:
   - aavarghese
   - lionelvillard
+  - matzew
   eventing-wg-leads:
   - devguyio
   - lionelvillard
@@ -121,6 +132,13 @@ aliases:
   kn-plugin-migration-approvers:
   - maximilien
   - zhangtbj
+  kn-plugin-operator-approvers:
+  - csantanapr
+  - dsimansk
+  - houshengbo
+  - maximilien
+  - omerbensaadon
+  - rhuss
   kn-plugin-quickstart-approvers:
   - csantanapr
   - omerbensaadon
@@ -142,7 +160,7 @@ aliases:
   - nicolaferraro
   - rhuss
   knative-admin:
-  - ZhiminXiang
+  - benmoss
   - bsnchan
   - dprotaso
   - evankanderson
@@ -155,11 +173,35 @@ aliases:
   - mbehrendt
   - pmorie
   - rhuss
+  - salaboy
   - thisisnotapril
   - vaikas
-  knative-release-leads:
+  knative-milestone-maintainers:
   - ZhiminXiang
+  - akashrv
+  - aslom
+  - chaodaiG
+  - csantanapr
+  - dprotaso
   - evankanderson
+  - josephburnett
+  - julz
+  - k4leung4
+  - lionelvillard
+  - markusthoemmes
+  - matzew
+  - mikehelmick
+  - n3wscott
+  - nak3
+  - navidshaikh
+  - rhuss
+  - tcnghia
+  - vagababov
+  - vaikas
+  knative-release-leads:
+  - benmoss
+  - julz
+  - salaboy
   knative-robots:
   - knative-prow-releaser-robot
   - knative-prow-robot
@@ -174,11 +216,11 @@ aliases:
   net-contour-approvers:
   - dprotaso
   - tcnghia
-  net-http01-approvers:
-  - tcnghia
-  net-ingressv2-approvers:
+  net-gateway-api-approvers:
   - markusthoemmes
   - nak3
+  - tcnghia
+  net-http01-approvers:
   - tcnghia
   net-istio-approvers:
   - JRBANCEL


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

I've noticed an unwanted  change from community update [PR](https://github.com/knative-sandbox/kn-plugin-operator/pull/12). Hence owners aliases aren't up-to-date currently.


Updated with:
```
./hack/update-codegen.sh
```

# Changes

- :broom: Regenerate owner aliases to be up-to-date
