### PR TITLE
Re-regenerate OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -69,7 +69,7 @@ aliases:
   - pierDipi
   - vaikas
   knative-admin:
-  - ZhiminXiang
+  - benmoss
   - bsnchan
   - dprotaso
   - duglin
@@ -84,12 +84,14 @@ aliases:
   - omerbensaadon
   - pmorie
   - rhuss
+  - salaboy
   - spencerdillard
   - thisisnotapril
   - vaikas
   knative-release-leads:
-  - ZhiminXiang
-  - evankanderson
+  - benmoss
+  - julz
+  - salaboy
   knative-robots:
   - knative-prow-releaser-robot
   - knative-prow-robot
@@ -100,6 +102,7 @@ aliases:
   - ZhiminXiang
   - andrew-su
   - arturenault
+  - carlisia
   - markusthoemmes
   - nak3
   - shashwathi
@@ -157,6 +160,7 @@ aliases:
   - evankanderson
   - gerardo-lc
   - joshua-bone
+  - kvmware
   - steuhs
   productivity-wg-leads:
   - chizhg
@@ -178,7 +182,9 @@ aliases:
   serving-observability-writers:
   - yanweiguo
   serving-reviewers:
+  - carlisia
   - julz
+  - nealhu
   - psschwei
   - whaught
   serving-writers:

--- a/knative-sandbox-OWNERS_ALIASES
+++ b/knative-sandbox-OWNERS_ALIASES
@@ -19,6 +19,10 @@ aliases:
   - dsimansk
   - navidshaikh
   - rhuss
+  container-freezer-approvers:
+  - julz
+  - markusthoemmes
+  - psschwei
   control-protocol-approvers:
   - devguyio
   - eric-sap
@@ -37,18 +41,23 @@ aliases:
   - zroubalik
   eventing-awssqs-approvers:
   - lberk
+  - matzew
   eventing-camel-approvers:
   - nicolaferraro
   eventing-ceph-approvers:
   - lberk
+  - matzew
   eventing-couchdb-approvers:
   - lberk
   - lionelvillard
+  - matzew
   eventing-github-approvers:
   - lberk
+  - matzew
   eventing-gitlab-approvers:
   - antoineco
   - lberk
+  - matzew
   - sebgoa
   - tzununbekov
   eventing-kafka-approvers:
@@ -83,6 +92,7 @@ aliases:
   - zhaojizhuang
   eventing-prometheus-approvers:
   - lberk
+  - matzew
   eventing-rabbitmq-approvers:
   - benmoss
   - sbawaska
@@ -91,6 +101,7 @@ aliases:
   eventing-redis-approvers:
   - aavarghese
   - lionelvillard
+  - matzew
   eventing-wg-leads:
   - devguyio
   - lionelvillard
@@ -121,6 +132,13 @@ aliases:
   kn-plugin-migration-approvers:
   - maximilien
   - zhangtbj
+  kn-plugin-operator-approvers:
+  - csantanapr
+  - dsimansk
+  - houshengbo
+  - maximilien
+  - omerbensaadon
+  - rhuss
   kn-plugin-quickstart-approvers:
   - csantanapr
   - omerbensaadon
@@ -142,7 +160,7 @@ aliases:
   - nicolaferraro
   - rhuss
   knative-admin:
-  - ZhiminXiang
+  - benmoss
   - bsnchan
   - dprotaso
   - evankanderson
@@ -155,11 +173,13 @@ aliases:
   - mbehrendt
   - pmorie
   - rhuss
+  - salaboy
   - thisisnotapril
   - vaikas
   knative-release-leads:
-  - ZhiminXiang
-  - evankanderson
+  - benmoss
+  - julz
+  - salaboy
   knative-robots:
   - knative-prow-releaser-robot
   - knative-prow-robot
@@ -174,11 +194,11 @@ aliases:
   net-contour-approvers:
   - dprotaso
   - tcnghia
-  net-http01-approvers:
-  - tcnghia
-  net-ingressv2-approvers:
+  net-gateway-api-approvers:
   - markusthoemmes
   - nak3
+  - tcnghia
+  net-http01-approvers:
   - tcnghia
   net-istio-approvers:
   - JRBANCEL

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -734,33 +734,6 @@ orgs:
             - julz
             - benmoss
             - salaboy
-      Knative Milestone Maintainers:
-        description: 'DO NOT RENAME - this group is used by Prow to control who can
-          manipulate milestones: https://github.com/knative/test-infra/blob/64615f92c4ebdd4e4423015ffc0db45877660a0d/ci/prow/plugins.yaml#L49'
-        privacy: closed
-        maintainers:
-        - rhuss
-        - markusthoemmes
-        - evankanderson
-        - julz
-        - dprotaso
-        members:
-        - akashrv
-        - aslom
-        - chaodaiG
-        - csantanapr
-        - josephburnett
-        - k4leung4
-        - lionelvillard
-        - mikehelmick
-        - n3wscott
-        - nak3
-        - navidshaikh
-        - tcnghia
-        - vagababov
-        - vaikas
-        - ZhiminXiang
-        - matzew
       Operations Writers:
         description: Grants write access to operations-related repositories.
         privacy: closed

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -888,35 +888,6 @@ orgs:
             - julz
             - benmoss
             - salaboy
-      Knative Milestone Maintainers:
-        description: 'DO NOT RENAME - this group is used by Prow to control who can manipulate
-          milestones: https://github.com/knative/test-infra/blob/64615f92c4ebdd4e4423015ffc0db45877660a0d/ci/prow/plugins.yaml#L49'
-        maintainers:
-        - rhuss
-        - markusthoemmes
-        - evankanderson
-        - dprotaso
-        - julz
-        members:
-        - ImJasonH
-        - ZhiminXiang
-        - andrew-su
-        - aslom
-        - chaodaiG
-        - chizhg
-        - csantanapr
-        - igsong
-        - nak3
-        - navidshaikh
-        - shashwathi
-        - tanzeeb
-        - tcnghia
-        - vagababov
-        - vaikas
-        - n3wscott
-        - lionelvillard
-        - matzew
-        privacy: closed
       Networking Reviewers:
         description: Receive reviews for networking directories
         privacy: closed


### PR DESCRIPTION
I recognize we have #808 and #806, but they're old and don't include #801 and #802, which let me get on as a release lead 😄 . What a mess. I opened #809 so maybe we can avoid this problem more.