### PR TITLE
Update release schedule

### DIFF
--- a/mechanics/RELEASE-SCHEDULE.md
+++ b/mechanics/RELEASE-SCHEDULE.md
@@ -11,12 +11,13 @@ With that said, it can be useful to have a list of when future releases will hap
 
 | Release | Date       | EOL        | Min K8s Version | Notes                         |
 | ------- | ---------- | ---------- | --------------- | ----------------------------- |
-| 0.23    | 2021-05-18 | 2021-11-02 | 1.18            | Removes v1beta1 Eventing APIs |
 | 0.24    | 2021-06-29 | 2021-12-14 | 1.19            | |
 | 0.25    | 2021-08-10 | 2022-01-25 | 1.19            | |
 | 0.26    | 2021-09-21 | 2022-03-08 | 1.19            | |
-| 0.27    | 2021-11-02 | 2022-04-19 | 1.20            | |
-| 0.28    | 2021-12-14 | 2022-05-31 | 1.20            | |
+| 1.0     | 2021-11-02 | 2022-04-19 | 1.20            | |
+| 1.1     | 2021-12-14 | 2022-05-31 | 1.20            | |
+| 1.2     | 2022-01-25 | 2022-06-12 | 1.21            | |
+| 1.3     | 2022-03-08 | 2022-07-24 | 1.21            | |
 
 
 ## Historical (no longer supported) releases:
@@ -33,4 +34,4 @@ With that said, it can be useful to have a list of when future releases will hap
 | 0.20    | 2021-01-12 | 2021-06-29 | 1.17            | ** Moved by 3 weeks for end of year holidays** |
 | 0.21    | 2021-02-23 | 2021-08-10 | 1.18            | |
 | 0.22    | 2021-04-06 | 2021-09-21 | 1.18            | |
-
+| 0.23    | 2021-05-18 | 2021-11-02 | 1.18            | Removes v1beta1 Eventing APIs |


### PR DESCRIPTION
Update to 0.27 being 1.0, and add some more subsequent releases with the help of Googling "six weeks from ...".

K8s 1.20 will go into maintenance mode on on 2021-12-28 so looks like 1.2 will drop support for it.