### PR TITLE
Change the number of elected seats in this election properly to two.

### DIFF
--- a/elections/2021-SC/README.md
+++ b/elections/2021-SC/README.md
@@ -9,9 +9,10 @@ type: "docs"
 
 ## Purpose
 
-The role of this election is to fill out the three (3) seats due for election
+The role of this election is to fill out the two (2) seats due for election
 this year on the [Knative Steering Committee]. Each elected member will serve a
-two (2) year term.
+two (2) year term.  The newly elected SC will, in turn, select the End User
+representative.
 
 ## Background
 
@@ -57,7 +58,7 @@ You can reach us by emailing elections@knative.team
 
 **Nomination**
 
-If you want to stand for election, open a PR against the
+If you want to stand for election for a Contributor Seat, open a PR against the
 [knative/community repository](https://github.com/knative/community) to include
 your candidate profile in the `/elections/2021-SC` folder, with the following
 filename format:
@@ -93,6 +94,9 @@ merge the profile PR.
 
 If you want to nominate someone else, you may do so, but PLEASE talk to them
 first.
+
+End Users interested in the End User seat will have a separate nomination 
+process (TBD) after the main election.
 
 **Campaigning**
 

--- a/elections/2021-SC/election.yaml
+++ b/elections/2021-SC/election.yaml
@@ -2,7 +2,7 @@ name: Knative 2021 Steering Committee Election
 organization: Knative
 start_datetime: 2021-11-10 00:00:01
 end_datetime: 2021-11-29 23:59:00
-no_winners: 3
+no_winners: 2
 allow_no_opinion: True
 delete_after: True
 show_candidate_fields:

--- a/elections/2021-SC/election_desc.md
+++ b/elections/2021-SC/election_desc.md
@@ -1,6 +1,6 @@
 # 2021 Voters Guide - Knative Steering Election
 
-The role of this election is to fill the three (3) seats due for election this year on the [Knative Steering Committee](https://github.com/knative/community/blob/master/STEERING-COMMITTEE.md). The elected members will serve two (2) year terms. This election will shape the future of Knative as a community and project.
+The role of this election is to fill the two (2) Contributor seats due for election this year on the [Knative Steering Committee](https://github.com/knative/community/blob/master/STEERING-COMMITTEE.md). The elected members will serve two (2) year terms. This election will shape the future of Knative as a community and project.
 
 This is a brief summary of the election; for more details, such as how to become a candidate, [see the README](https://github.com/knative/community/blob/main/elections/2021-SC/README.md).
 


### PR DESCRIPTION
Add notes about the seperate process for the End User seat.

As discussed, while three seats will change in this election, only the two Contributing Seats will be elected via Elekto.  The remaining seat will be selected by the newly seated SC.  This clarifies both the README and the description.

/assign @geekygirldawn, @vaikas 