### PR TITLE
Add verify-codegen workflow

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,73 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is **********NOT********** automagically synced here by knobots
+# because its too hard to opt-in to a single action. See
+# https://github.com/knative-sandbox/knobots/pull/99 for a potential solution.
+
+name: Verify
+
+on:
+  pull_request:
+    branches: [ 'main' ]
+
+jobs:
+
+  verify:
+    name: Verify Deps and Codegen
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        platform: [ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      id: go
+
+    - name: Install Dependencies
+      run: |
+        go install github.com/google/ko@latest
+        go install github.com/google/go-licenses@latest
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Update Codegen
+      shell: bash
+      run: ./hack/update-codegen.sh
+    - name: Verify
+      shell: bash
+      run: |
+        # From: https://backreference.org/2009/12/23/how-to-match-newlines-in-sed/
+        # This is to leverage this workaround:
+        # https://github.com/actions/toolkit/issues/193#issuecomment-605394935
+        function urlencode() {
+          sed ':begin;$!N;s/\n/%0A/;tbegin'
+        }
+        if [[ -z "$(git status --porcelain)" ]]; then
+            echo "${{ github.repository }} up to date."
+        else
+            # Print it both ways because sometimes we haven't modified the file (e.g. zz_generated),
+            # and sometimes we have (e.g. configmap checksum).
+            echo "Found diffs in: $(git diff-index --name-only HEAD --)"
+            for x in $(git diff-index --name-only HEAD --); do
+                echo "::error file=$x::Please run ./hack/update-codegen.sh.%0A$(git diff $x | urlencode)"
+            done
+            echo "${{ github.repository }} is out of date. Please run hack/update-codegen.sh"
+            exit 1
+        fi


### PR DESCRIPTION
Do it manually because the only thing knobots supports is a denylist, and it's too annoying to bother excluding every action except this single one.

If https://github.com/knative-sandbox/knobots/pull/99 was complete/merged this would be a lot easier, but unfortunately that's a dramatic refactoring that is now out of sync.


