### PR TITLE
Replace Omer Bensaadon with Evan Anderson as VMware Trademark representative

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -87,7 +87,6 @@ aliases:
   - matzew
   - mbehrendt
   - nak3
-  - omerbensaadon
   - pmorie
   - rhuss
   - spencerdillard
@@ -214,7 +213,7 @@ aliases:
   - rhuss
   trademark-committee:
   - duglin
-  - omerbensaadon
+  - evankanderson
   - spencerdillard
   ux-wg-leads:
   - csantanapr

--- a/TRADEMARK-COMMITTEE.md
+++ b/TRADEMARK-COMMITTEE.md
@@ -79,10 +79,7 @@ the trademark committee invites your feedback there. See
 | ------------------------ | ------------ | ---------------------------------------------------- |
 | Spencer Dillard          | Google       | [@spencerdillard](https://github.com/spencerdillard) |
 | Doug Davis               | IBM/RedHat   | [@duglin](https://github.com/duglin)                 |
-| Omer Bensaadon           | VMware       | [@omerbensaadon](https://github.com/omerbensaadon)|
-
-Committee members for bootstrap term will be chosen during the Steering
-Committee election process.
+| Evan Anderson            | VMware       | [@evankanderson](https://github.com/evankanderson)   |
 
 ## Decision process
 

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -872,7 +872,7 @@ orgs:
           Trademark Committee:
             description: Knative Trademark Committee
             maintainers:
-            - omerbensaadon
+            - evankanderson
             - duglin
             - spencerdillard
             privacy: closed


### PR DESCRIPTION
/assign @omerbensaadon
/assign @pmorie
