### PR TITLE
Markus steps down as Autoscaling WG lead

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,12 +9,9 @@ aliases:
   - psschwei
   - taragu
   autoscaling-wg-leads:
-  - markusthoemmes
-  - vagababov
+  - julz
   autoscaling-writers:
   - julz
-  - markusthoemmes
-  - vagababov
   - yanweiguo
   client-reviewers:
   - itsmurugappan
@@ -106,7 +103,6 @@ aliases:
   - andrew-su
   - arturenault
   - carlisia
-  - markusthoemmes
   - nak3
   - shashwathi
   - tcnghia
@@ -125,7 +121,6 @@ aliases:
   - aliok
   - houshengbo
   - jcrossley3
-  - markusthoemmes
   - matzew
   - trshafer
   operations-wg-leads:
@@ -135,7 +130,6 @@ aliases:
   - aliok
   - houshengbo
   - jcrossley3
-  - markusthoemmes
   - matzew
   - trshafer
   pkg-configmap-reviewers:

--- a/knative-sandbox-OWNERS_ALIASES
+++ b/knative-sandbox-OWNERS_ALIASES
@@ -9,8 +9,7 @@ aliases:
   - julz
   - maximilien
   autoscaling-wg-leads:
-  - markusthoemmes
-  - vagababov
+  - julz
   client-wg-leads:
   - dsimansk
   - navidshaikh
@@ -21,7 +20,6 @@ aliases:
   - rhuss
   container-freezer-approvers:
   - julz
-  - markusthoemmes
   - psschwei
   control-protocol-approvers:
   - devguyio
@@ -236,9 +234,8 @@ aliases:
   serving-writers:
   - ZhiminXiang
   - dprotaso
-  - markusthoemmes
+  - julz
   - nak3
-  - vagababov
   source-wg-leads:
   - lionelvillard
   steering-committee:

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -796,8 +796,7 @@ orgs:
           Autoscaling WG Leads:
             description: The Working Group leads for Autoscaling
             members:
-            - vagababov
-            - markusthoemmes
+            - julz
             privacy: closed
           Networking WG Leads:
             description: The Working Group leads for Networking
@@ -832,7 +831,6 @@ orgs:
         repos:
           container-freezer: write
         members:
-        - markusthoemmes
         - julz
         - psschwei
 

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -712,8 +712,7 @@ orgs:
           Autoscaling WG Leads:
             description: The Working Group leads for Autoscaling
             members:
-            - vagababov
-            - markusthoemmes
+            - julz
             privacy: closed
       Client Reviewers:
         description: Receive reviews for client directories
@@ -898,7 +897,6 @@ orgs:
         - arturenault
         - carlisia
         - JRBANCEL
-        - markusthoemmes
         - nak3
         - shashwathi
         - tcnghia
@@ -930,7 +928,6 @@ orgs:
         - Cynocracy
         - houshengbo
         - jcrossley3
-        - markusthoemmes
         - matzew
         - trshafer
       Operations Writers:
@@ -942,7 +939,6 @@ orgs:
         - aliok
         - Cynocracy
         - jcrossley3
-        - markusthoemmes
         - matzew
         - trshafer
         teams:

--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -321,14 +321,15 @@ Autoscaling behavior of Knative Serving
 | Slack Channel              | [#autoscaling](https://slack.knative.dev/messages/autoscaling)                                                                                              |
 | Github Team WG leads       | [@knative/autoscaling-wg-leads](https://github.com/orgs/knative/teams/autoscaling-wg-leads/members)                                                         |
 
-| &nbsp;                                                         | Leads          | Company | Profile                                             |
-| -------------------------------------------------------------- | -------------- | ------- | --------------------------------------------------- |
-| <img width="30px" src="https://github.com/markusthoemmes.png"> | Markus Thömmes | Red Hat | [markusthoemmes](https://github.com/markusthoemmes) |
+| &nbsp;                                                         | Leads           | Company | Profile                                             |
+| -------------------------------------------------------------- | --------------- | ------- | --------------------------------------------------- |
+| <img width="30px" src="https://github.com/julz.png">           | Julian Friedman | IBM     | [julz](https://github.com/julz)                     |
 
-| &nbsp;                                                        | Emeritus Leads  | Profile                                           | Duration  |
-| ------------------------------------------------------------- | --------------- | ------------------------------------------------- | --------- |
-| <img width="30px" src="https://github.com/vagababov.png">     | Victor Agababov | [vagababov](https://github.com/vagababov)         | 2019-2021 |
-| <img width="30px" src="https://github.com/josephburnett.png"> | Joseph Burnett  | [josephburnett](https://github.com/josephburnett) | 2018-2019 |
+| &nbsp;                                                         | Emeritus Leads  | Profile                                             | Duration  |
+| -------------------------------------------------------------- | --------------- | --------------------------------------------------- | --------- |
+| <img width="30px" src="https://github.com/markusthoemmes.png"> | Markus Thömmes  | [markusthoemmes](https://github.com/markusthoemmes) | 2019-2021 |
+| <img width="30px" src="https://github.com/vagababov.png">      | Victor Agababov | [vagababov](https://github.com/vagababov)           | 2019-2021 |
+| <img width="30px" src="https://github.com/josephburnett.png">  | Joseph Burnett  | [josephburnett](https://github.com/josephburnett)   | 2018-2019 |
 
 ## Security
 


### PR DESCRIPTION
As per https://groups.google.com/g/knative-dev/c/gA3matxzBH4/m/zxQKWqkXAgAJ I'm stepping down from being Autoscaling WG lead. @julz is taking over in the interim.

I've included some other cleanups of my RBAC and only keep the TOC relevant bits. I'll hash out when to send the TOC updates together with the TOC.

/kind cleanup
/kind removal

/assign @evankanderson @dprotaso @rhuss @julz 