### PR TITLE
Add @snneji to knative-sandbox members

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -227,6 +227,7 @@ orgs:
     - skim1420
     - smarterclayton
     - smoser-ibm
+    - snneji
     - spolti
     - srvaroa
     - ssisil


### PR DESCRIPTION
As @snneji is not in the member list in knative-sandbox, all community file updates PRs are failing with the error `snneji
User is not a member of the org. User is not a collaborator. Satisfy at least one of these conditions to make the user trusted.`.
e.g.
https://github.com/knative-sandbox/net-kourier/pull/733
https://github.com/knative-sandbox/net-istio/pull/834

/cc @csantanapr @snneji @evankanderson 