### PR TITLE
Remove kimsterv to fix peribolos CI runs

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -274,7 +274,6 @@ orgs:
     - kelseyhightower
     - kevball
     - kimikowang
-    - kimsterv
     - kitmerker-jfrog
     - knative-automation
     - knative-metrics-robot


### PR DESCRIPTION
https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-peribolos/1470075994139267072#1:build-log.txt%3A28 is the current failing run.

Issue is tracked in https://github.com/knative/community/issues/186.

cc @kimsterv