### PR TITLE
Add Paul Schweigert as docs approver (docs-writer)

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -41,6 +41,7 @@ aliases:
   docs-writers:
   - abrennan89
   - csantanapr
+  - psschwei
   - snneji
   eventing-reviewers:
   - aslom

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -31,8 +31,6 @@ aliases:
   - omerbensaadon
   - salaboy
   docs-reviewers:
-  - RichardJJG
-  - mpetason
   - nainaz
   - omerbensaadon
   - pmbanugo
@@ -41,11 +39,8 @@ aliases:
   - csantanapr
   - snneji
   docs-writers:
-  - RichardJJG
   - abrennan89
-  - carieshmarie
   - csantanapr
-  - richieescarez
   - snneji
   eventing-reviewers:
   - aslom

--- a/knative-sandbox-OWNERS_ALIASES
+++ b/knative-sandbox-OWNERS_ALIASES
@@ -37,6 +37,7 @@ aliases:
   docs-writers:
   - abrennan89
   - csantanapr
+  - psschwei
   - snneji
   eventing-autoscaler-keda-approvers:
   - zroubalik

--- a/knative-sandbox-OWNERS_ALIASES
+++ b/knative-sandbox-OWNERS_ALIASES
@@ -32,9 +32,12 @@ aliases:
   - lberk
   - n3wscott
   docs-wg-leads:
-  - abrennan89
+  - csantanapr
+  - snneji
   docs-writers:
   - abrennan89
+  - csantanapr
+  - snneji
   eventing-autoscaler-keda-approvers:
   - zroubalik
   eventing-awssqs-approvers:

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -603,8 +603,11 @@ orgs:
           Docs WG Leads:
             description: The Working Group leads for Docs
             members:
-            - abrennan89
+            - csantanapr
+            - snneji
             privacy: closed
+        members:
+        - abrennan89
       Eventing Writers:
         description: Grants write access to eventing-related repositories.
         privacy: closed

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -608,6 +608,7 @@ orgs:
             privacy: closed
         members:
         - abrennan89
+        - psschwei
       Eventing Writers:
         description: Grants write access to eventing-related repositories.
         privacy: closed

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -774,6 +774,7 @@ orgs:
             privacy: closed
         members:
         - abrennan89
+        - psschwei
       Eventing Reviewers:
         description: Receive reviews for docs directories
         privacy: closed

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -754,9 +754,7 @@ orgs:
         description: Receive reviews for docs directories
         privacy: closed
         members:
-        - mpetason
         - omerbensaadon
-        - RichardJJG
         - snneji
         - pmbanugo
         - nainaz
@@ -776,10 +774,6 @@ orgs:
             privacy: closed
         members:
         - abrennan89
-        - carieshmarie
-        - richieescarez
-        - snneji
-        - RichardJJG
       Eventing Reviewers:
         description: Receive reviews for docs directories
         privacy: closed


### PR DESCRIPTION
We understand that @psschwei is a great candidate to be an approver for [docs git repository](https://github.com/knative/docs).  

The DUX Working Group would like to nominate @psschwei to be an approver and understand that it meets all the [requirements](https://github.com/knative/community/blob/main/ROLES.md#requirements-1) stated in our governance documentation for [ROLES](https://github.com/knative/community/blob/main/ROLES.md). 

- [x] Reviewer of the codebase for at least 3 months.
- [x] Primary reviewer for at least 10 substantial PRs to the codebase.
@psschwei submitted the following PRs in the last 3 months (12):
1. knative/docs#4285
1. knative/docs#4260 
1. knative/docs#4299
1. knative/docs#4298
1. knative/docs#4333
1. knative/docs#4409
1. knative/docs#4412
1. knative/docs#4413
1. knative/docs#4431
1. knative/docs#4391
1. knative/docs#4442
1. knative/docs#4416

@psschwei have reviewed the following PRs in the last 3 months (13)
1. knative/docs#4194
2. knative/docs#4428
3. knative/docs#4434
4. knative/docs#4435
5. knative/docs#4486
6. knative/docs#4517
7. knative/docs#4539
8. knative/docs#4544
9. knative/docs#4565
10. knative/docs#4566
11. knative/docs#4572
12. knative/docs#4577
13. knative/docs#4578

- [x] Nominated by a WG lead (with no objections from other leads).
Was discussed to nominate Paul to be an approver of docs git repo by DUX WG leads (@csantanapr and @snneji ) during the DUX WG meeting on 2021-12-13. There were no objections in DUX WG Meeting. See agenda and recording for more details https://docs.google.com/document/d/1NSlGHen5Dh6c2A0LGavGWibddWrlSLV_PbEbMpNjSTU/edit

