### PR TITLE
Add cardil@ as productivity writer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -149,13 +149,12 @@ aliases:
   - efiturri
   - evankanderson
   - gerardo-lc
-  - joshua-bone
   - kvmware
   - shinigambit
-  - steuhs
   productivity-wg-leads:
   - chizhg
   productivity-writers:
+  - cardil
   - chaodaiG
   - chizhg
   - coryrc

--- a/knative-sandbox-OWNERS_ALIASES
+++ b/knative-sandbox-OWNERS_ALIASES
@@ -230,6 +230,7 @@ aliases:
   productivity-wg-leads:
   - chizhg
   productivity-writers:
+  - cardil
   - chizhg
   - psschwei
   security-wg-leads:

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -765,6 +765,7 @@ orgs:
           knobots: write
         members:
           - psschwei
+          - cardil
         teams:
           Productivity WG Leads:
             description: The Working Group leads for Productivity

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -976,9 +976,7 @@ orgs:
         - efiturri
         - evankanderson
         - gerardo-lc
-        - joshua-bone
         - shinigambit
-        - steuhs
         - kvmware
       Productivity Writers:
         description: Grants write access to productivity-related repositories.
@@ -992,6 +990,7 @@ orgs:
         - chaodaiG
         - coryrc
         - psschwei
+        - cardil
         teams:
           Productivity WG Leads:
             description: The Working Group leads for Productivity


### PR DESCRIPTION
Chris has contributed to Knative productivity since 2019, and he had made a lot of great achievements on improving Knative testing, specifically upgrade testing, conformance testing and the general testing infrastructure.

I believe he has met all the requirements from a long while ago, so nominating cardil@ as a productivity writer.

Also removing two Googlers that have left Knative.

/cc @vaikas @csantanapr 

FYI @cardil 