### PR TITLE
remove myself from rabbitmq

### DIFF
--- a/knative-sandbox-OWNERS_ALIASES
+++ b/knative-sandbox-OWNERS_ALIASES
@@ -98,7 +98,6 @@ aliases:
   - lberk
   - matzew
   eventing-rabbitmq-approvers:
-  - benmoss
   - chunyilyu
   - gabo1208
   - gvmw

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -996,7 +996,6 @@ orgs:
           eventing-rabbitmq: write
         members:
         - salaboy
-        - benmoss
         - xtreme-sameer-vohra
         - gvmw
         - ikvmw


### PR DESCRIPTION
I'm not participating in eventing-rabbitmq anymore so just to avoid getting mentions from the team alias