### PR TITLE
GSOC 22 Idea: Improve Knative Eventing Observability

### DIFF
--- a/google-summer-of-code/gsoc-2022.md
+++ b/google-summer-of-code/gsoc-2022.md
@@ -142,3 +142,45 @@ Associated Knative modules and other open source projects:
 ### Idea list
 
 
+#### Improve Knative Eventing Observability End-to-End by addressing top issues identified by community  
+
+Summary of idea: Today, Knative Eventing has some support for observability 
+[1](https://knative.dev/docs/eventing/observability/logging/collecting-logs/)
+[2](https://knative.dev/docs/eventing/accessing-traces/)
+[3](https://knative.dev/docs/eventing/troubleshooting/)
+but it is piecewise and user needs for end-to-end observability are not fully addressed 
+[4](https://github.com/knative/eventing/issues/3387)
+[5](https://github.com/knative-sandbox/eventing-kafka/issues/29)
+[6](https://github.com/lionelvillard/kn-trace).
+The idea is to find out what are the biggest gaps in Knative Eventing by asking the community. 
+Then to find a few issues that are “low hanging” fruits that can be solved during summer 
+with the overall goal to to simplify end-to-end observability by improving 
+support for OpenTelemetry in Knative Eventing and/or create a new plugin(s) for kn CLI. 
+
+We see that work to be accomplished in stages:
+
+Initial Stage: Few weeks of getting used to knative-eventing with few sample applications, 
+reach out to Knative Eventing community via mailing list and Knative Slack 
+to ask for interviews or feedback on what are biggest problems 
+with observability in Knative Eventing
+
+-Feature A (few weeks)
+First Stage: Identify the highest priority problem that can be solved in 1-2 weeks (small size)
+Share the solution, gather feedback
+
+-Feature B (few weeks)
+Second Stage: Either improve the Feature A solution and/or address larger problem 3-4 weeks
+
+Final Stage (last weeks of summer): Write Knative docs, blog post, advertise
+
+Knowledge prerequisite: Golang
+
+Github repo: knative-sandbox 
+
+Skill level: Intermediate to Advanced
+
+Contact(s) / potential mentors(s): Aleksander Slominski @aslom, Ansu Varghese @aavarghese, and Lionel Villard @lionelvillard
+
+Associated Knative modules and other open source projects: knative eventing, knative client, prometheus, jaeger, open-telemetry
+
+


### PR DESCRIPTION
Described the idea for GSOC 22 following the template
https://github.com/knative/community/blob/main/google-summer-of-code/gsoc-2022.md#ideas 

