### PR TITLE
Add google-ospo-team as the owner of Knative orgs

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -15,6 +15,7 @@ orgs:
     - dprotaso
     - evankanderson
     - google-admin
+    - google-ospo-team
     - googlebot
     - itsmurugappan
     - julz

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -12,6 +12,7 @@ orgs:
     - dprotaso
     - evankanderson
     - google-admin
+    - google-ospo-team
     - googlebot
     - julz
     - itsmurugappan


### PR DESCRIPTION
We can remove all the Google-owned bot accounts after Knative becomes part of CNCF.