### PR TITLE
Reconcile GSuite Groups

### DIFF
--- a/groups/README.md
+++ b/groups/README.md
@@ -1,25 +1,16 @@
 # Automation of Google Groups maintenance for `knative.team`
 
 - [Making changes](#making-changes)
-  - [Staging access groups](#staging-access-groups)
 - [Manual deploy](#manual-deploy)
 
 ## Making changes
 
-- Edit your SIG's `groups.yaml`, e.g. [`sig-release/groups.yaml`][/groups/sig-release/groups.yaml]
+- Edit your WGs's `groups.yaml`, e.g. [`wg-security/groups.yaml`][/groups/wg-security/groups.yaml]
 - If adding or removing a group, edit [`restrictions.yaml`] to add or remove the group name
 - Use `make test` to ensure the changes meet conventions
 - Open a pull request
 - When the pull request merges, the [post-k8sio-groups] job will deploy the changes
 
-### Staging access groups
-
-Google Groups for granting push access to container repositories and/or buckets
-must be of the form:
-
-```console
-k8s-infra-staging-<project-name>@knative.team
-```
 
 **The project name has a max length of 18 characters.**
 
@@ -30,7 +21,7 @@ k8s-infra-staging-<project-name>@knative.team
 - Use `make run` to dry run the changes
 - Use `make run -- --confirm` if the changes suggested in the previous step looks good
 
-[post-k8sio-groups]: https://testgrid.k8s.io/sig-k8s-infra-k8sio#post-k8sio-groups
+[post-k8sio-groups]: https://testgrid.k8s.io/r/knative-own-testgrid/utilities#knativeteam-groups-jobs
 
 ## How does this work?
 

--- a/groups/committee-code-of-conduct/groups.yaml
+++ b/groups/committee-code-of-conduct/groups.yaml
@@ -5,6 +5,7 @@ groups:
       Group for handling Code of Conduct issues.
       Due to potentially sensitive nature of the issues discussed, this is a closed group.
     settings:
+      AllowExternalMembers: "false"
       ReconcileMembers: "true"
       WhoCanPostMessage: "ANYONE_CAN_POST"
     owners:

--- a/groups/committee-oversight/groups.yaml
+++ b/groups/committee-oversight/groups.yaml
@@ -5,6 +5,7 @@ groups:
     description: |-
       Technical Oversight Committee Email
     settings:
+      AllowExternalMembers: "false"
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:

--- a/groups/committee-oversight/groups.yaml
+++ b/groups/committee-oversight/groups.yaml
@@ -10,9 +10,10 @@ groups:
       ReconcileMembers: "true"
     owners:
       - markusthoemmes@knative.team
-    members:
       - evankanderson@knative.team
-      - grantr@knative.team
-      - mattmoor@knative.team
       - rhuss@knative.team
-
+      - evana@vmware.com
+      - evan.k.anderson@gmail.com
+    members:
+      - mattmoor@knative.team
+      - grantr@knative.team

--- a/groups/committee-oversight/groups.yaml
+++ b/groups/committee-oversight/groups.yaml
@@ -9,7 +9,6 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - markusthoemmes@knative.team
       - evankanderson@knative.team
       - rhuss@knative.team
       - evana@vmware.com
@@ -17,3 +16,4 @@ groups:
     members:
       - mattmoor@knative.team
       - grantr@knative.team
+      - markusthoemmes@knative.team

--- a/groups/committee-oversight/groups.yaml
+++ b/groups/committee-oversight/groups.yaml
@@ -13,6 +13,9 @@ groups:
       - rhuss@knative.team
       - evana@vmware.com
       - evan.k.anderson@gmail.com
+      - dprotaso@gmail.com
+      - n3wscott@knative.team
+      - rhuss@redhat.com
     members:
       - mattmoor@knative.team
       - grantr@knative.team

--- a/groups/committee-trademark/groups.yaml
+++ b/groups/committee-trademark/groups.yaml
@@ -7,6 +7,9 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - bsnchan@knative.team
+      - evana@vmware.com
       - duglin@gmail.com
-      - avnur@knative.team
+      - evankanderson@knative.team
+      - sdmoser@googlemail.com
+      - SMOSER@de.ibm.com
+      - spencerdillard@google.com

--- a/groups/config.yaml
+++ b/groups/config.yaml
@@ -4,7 +4,7 @@
 secret-version: projects/knative-gsuite/secrets/gsuite-group-manager_key/versions/latest
 
 # Email id of the bot service account
-bot-id: prow-robot@knative.team # TO BE CREATED
+bot-id: prow-robot@knative.team
 
 # Directory with groups.yaml files, relative to location of this config file
 groups-path: .

--- a/groups/wg-productivity/groups.yaml
+++ b/groups/wg-productivity/groups.yaml
@@ -1,9 +1,9 @@
 groups:
   #
-  # k8s-infra owners for sig-owned subprojects
+  # k8s-infra owners for Knative
   #
-  # Each group here represents highly privileged access to kubernetes project
-  # infrastructure owned or managed by this SIG. A high level of trust is
+  # Each group here represents highly privileged access to knative project
+  # infrastructure owned or managed by the Productivity WG. A high level of trust is
   # required for membership in these groups.
   #
 
@@ -14,7 +14,7 @@ groups:
   - email-id: kn-infra-gcp-org-admins@knative.team
     name: kn-infra-gcp-org-admins
     description: |-
-      granted owner access to the knative.team GCP organization, as well as
+      grants owner access to the knative.team GCP organization, as well as
       additional privileges necessary for billing and admin purposes
 
       access granted via custom organization role organization.admin
@@ -63,6 +63,7 @@ groups:
       User group for administrators of knative-automation.
     settings:
       AllowExternalMembers: "true"
+      ReconcileMembers: "true"
     owners:
       - evana@gcp.vmware.com
       - evankanderson@knative.team


### PR DESCRIPTION
Follow up from #905


The prowjob is broken intentionally, but I'll fix it once the PR is merged. After that point, GSuite must be managed through this repo.
﻿
- Reconciled the current group membership, trademark committee added some new members.
- https://prow.knative.dev/?repo=knative%2Fcommunity

