### PR TITLE
Add Krsna and Mahamed as productivity writers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -155,7 +155,6 @@ aliases:
   - efiturri
   - evankanderson
   - gerardo-lc
-  - kvmware
   - mgencur
   - shinigambit
   productivity-wg-leads:
@@ -165,7 +164,9 @@ aliases:
   - chaodaiG
   - chizhg
   - coryrc
+  - kvmware
   - psschwei
+  - upodroid
   security-wg-leads:
   - evankanderson
   - julz

--- a/knative-sandbox-OWNERS_ALIASES
+++ b/knative-sandbox-OWNERS_ALIASES
@@ -234,8 +234,12 @@ aliases:
   - chizhg
   productivity-writers:
   - cardil
+  - chaodaiG
   - chizhg
+  - coryrc
+  - kvmware
   - psschwei
+  - upodroid
   security-wg-leads:
   - evankanderson
   - julz

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -761,8 +761,12 @@ orgs:
           kperf: write
           knobots: write
         members:
-          - psschwei
-          - cardil
+        - cardil
+        - chaodaiG
+        - coryrc
+        - kvmware
+        - psschwei
+        - upodroid
         teams:
           Productivity WG Leads:
             description: The Working Group leads for Productivity

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -990,7 +990,6 @@ orgs:
         - gerardo-lc
         - shinigambit
         - mgencur
-        - kvmware
       Productivity Writers:
         description: Grants write access to productivity-related repositories.
         privacy: closed
@@ -1002,10 +1001,12 @@ orgs:
           hack: write
           release: write
         members:
+        - cardil
         - chaodaiG
         - coryrc
+        - kvmware
         - psschwei
-        - cardil
+        - upodroid
         teams:
           Productivity WG Leads:
             description: The Working Group leads for Productivity


### PR DESCRIPTION
Both Krsna and Mahamed have been very active contributors for Knative productivity for the last 3 months, I propose adding them as productivity writers.

Also updating the config for `knative-sandbox` to keep it in sync with `knative`.

cc @kvmware @upodroid 

/cc @vaikas @csantanapr 