### PR TITLE
Ahmed stepping down from eventing and eventing-kafka wg leads and approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -53,13 +53,11 @@ aliases:
   - antoineco
   - lberk
   eventing-wg-leads:
-  - devguyio
   - lionelvillard
   eventing-writers:
   - akashrv
   - aliok
   - antoineco
-  - devguyio
   - lberk
   - lionelvillard
   - matzew

--- a/knative-sandbox-OWNERS_ALIASES
+++ b/knative-sandbox-OWNERS_ALIASES
@@ -22,7 +22,6 @@ aliases:
   - julz
   - psschwei
   control-protocol-approvers:
-  - devguyio
   - eric-sap
   - lionelvillard
   - matzew
@@ -65,7 +64,6 @@ aliases:
   eventing-kafka-approvers:
   - aliok
   - davyodom
-  - devguyio
   - eric-sap
   - lberk
   - matzew
@@ -80,11 +78,9 @@ aliases:
   eventing-kafka-mtsource-approvers:
   - steven0711dong
   eventing-kafka-wg-leads:
-  - devguyio
   - lionelvillard
   - travis-minke-sap
   eventing-kafka-writers:
-  - devguyio
   - lionelvillard
   - travis-minke-sap
   eventing-kogito-approvers:
@@ -92,7 +88,6 @@ aliases:
   - spolti
   - vaibhavjainwiz
   eventing-natss-approvers:
-  - devguyio
   - zhaojizhuang
   eventing-prometheus-approvers:
   - lberk
@@ -109,11 +104,9 @@ aliases:
   - lionelvillard
   - matzew
   eventing-wg-leads:
-  - devguyio
   - lionelvillard
   eventing-writers:
   - aliok
-  - devguyio
   - lionelvillard
   - matzew
   - odacremolbap

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -641,7 +641,6 @@ orgs:
           Eventing WG Leads:
             description: The Working Group leads for Eventing
             members:
-            - devguyio
             - lionelvillard
             privacy: closed
         members:
@@ -660,7 +659,6 @@ orgs:
           Eventing Kafka WG Leads:
             description: The Working Group leads for Eventing Kafka
             members:
-            - devguyio
             - lionelvillard
             - travis-minke-sap
       Knative Admin:
@@ -863,7 +861,6 @@ orgs:
         repos:
           control-protocol: write
         members:
-        - devguyio
         - eric-sap
         - matzew
         - lionelvillard
@@ -952,7 +949,6 @@ orgs:
         members:
         - aliok
         - davyodom
-        - devguyio
         - eric-sap
         - lberk
         - matzew
@@ -992,7 +988,6 @@ orgs:
         repos:
           eventing-natss: write
         members:
-        - devguyio
         - zhaojizhuang
 
       eventing-prometheus Approvers:

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -815,7 +815,6 @@ orgs:
           Eventing WG Leads:
             description: The Working Group leads for Eventing
             members:
-            - devguyio
             - lionelvillard
             privacy: closed
         members:

--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -172,12 +172,13 @@ Event sources, bindings, FaaS framework, and orchestration
 | &nbsp;                                                        | Leads                      | Company | Profile                                           |
 | ------------------------------------------------------------- | -------------------------- | ------- | ------------------------------------------------- |
 | <img width="30px" src="https://github.com/lionelvillard.png"> | Lionel Villard (Technical) | IBM     | [lionelvillard](https://github.com/lionelvillard) |
-| <img width="30px" src="https://github.com/devguyio.png">      | Ahmed Abdalla (Execution)  | Red Hat | [devguyio](https://github.com/devguyio)           |
 
-| &nbsp;                                                 | Emeritus Leads            | Profile                             | Duration  |
-| ------------------------------------------------------ | ------------------------- | ----------------------------------- | --------- |
-| <img width="30px" src="https://github.com/grantr.png"> | Grant Rodgers (Technical) | [grantr](https://github.com/grantr) | 2020-2021 |
-| <img width="30px" src="https://github.com/vaikas.png"> | Ville Aikas (Technical)   | [vaikas](https://github.com/vaikas) | 2018-2021 |
+
+| &nbsp;                                                  | Emeritus Leads            | Profile                                | Duration  |
+| ------------------------------------------------------- | ------------------------- | -------------------------------------- | --------- |
+| <img width="30px" src="https://github.com/devguyio.png">| Ahmed Abdalla (Execution) | [devguyio](https://github.com/devguyio)| 2021-2022 |
+| <img width="30px" src="https://github.com/grantr.png">  | Grant Rodgers (Technical) | [grantr](https://github.com/grantr)    | 2020-2021 |
+| <img width="30px" src="https://github.com/vaikas.png">  | Ville Aikas (Technical)   | [vaikas](https://github.com/vaikas)    | 2018-2021 |
 
 ## Eventing Kafka
 
@@ -197,11 +198,11 @@ A dedicated working group for Kafka-based Knative Eventing components.
 
 | &nbsp;                                                           | Leads           | Company | Profile                                           |
 | ---------------------------------------------------------------- | --------------- | ------- | ------------------------------------------------- |
-| <img width="30px" src="https://github.com/devguyio.png">         | Ahmed Abdalla   | Red Hat | [devguyio](https://github.com/devguyio)           |
 | <img width="30px" src="https://github.com/travis-minke-sap.png"> | Travis Minke    | SAP     | [travis-minke-sap](https://github.com/travis-minke-sap) |
 
 | &nbsp;                                                         | Emeritus Leads  | Profile                                             | Duration  |
 | -------------------------------------------------------------- | --------------- | --------------------------------------------------- | --------- |
+| <img width="30px" src="https://github.com/devguyio.png">       | Ahmed Abdalla   | [devguyio](https://github.com/devguyio)             | 2021-2022 |
 | <img width="30px" src="https://github.com/lionelvillard.png">  | Lionel Villard  | [lionelvillard](https://github.com/lionelvillard)   | 2021-2022 |
 
 ## Eventing Sources


### PR DESCRIPTION
As already announced [here](https://groups.google.com/g/knative-dev/c/IqlSNL7jvdo) , it's time to for me to return back to the observer seat. 

/kind cleanup
/kind removal

I also suggest that we shutdown the Eventing Kafka WG. Right now it has no leads and I'm not sure if @pierDipi or @matzew would be willing to keep it up. But I feel that's a followup after this PR.


/assign @evankanderson @dprotaso @rhuss @n3wscott 