### PR TITLE
remove efiturri who's not working on Knative anymore

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -153,7 +153,6 @@ aliases:
   - vagababov
   productivity-reviewers:
   - albertomilan
-  - efiturri
   - evankanderson
   - gerardo-lc
   - mgencur

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -986,7 +986,6 @@ orgs:
         privacy: closed
         members:
         - albertomilan
-        - efiturri
         - evankanderson
         - gerardo-lc
         - shinigambit


### PR DESCRIPTION
This is causing presubmit test failures in https://github.com/knative/infra/pull/2

/cc @dprotaso @kvmware 