### PR TITLE
Add caniszczyk and thelinuxfoundation as org OWNERS

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -140,6 +140,7 @@ orgs:
     - jrangelramos
     - JRBANCEL
     - jskeet
+    - julz
     - jzelinskie
     - k4leung4
     - knative-automation

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -11,16 +11,17 @@ orgs:
     members_can_create_repositories: false
     default_repository_permission: read
     admins:
+    - caniszczyk
     - csantanapr
     - dprotaso
     - evankanderson
     - google-admin
     - googlebot
     - itsmurugappan
-    - julz
     - knative-prow-robot
     - pmorie
     - rhuss
+    - thelinuxfoundation
     - thisisnotapril
     - vaikas
     members:

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -266,6 +266,7 @@ orgs:
     - JRBANCEL
     - jsanda
     - jskeet
+    - julz
     - justinjsmith
     - jzelinskie
     - k4leung4

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -8,16 +8,17 @@ orgs:
     members_can_create_repositories: false
     default_repository_permission: read
     admins:
+    - caniszczyk
     - csantanapr
     - dprotaso
     - evankanderson
     - google-admin
     - googlebot
-    - julz
     - itsmurugappan
     - knative-prow-robot
     - pmorie
     - rhuss
+    - thelinuxfoundation
     - thisisnotapril
     - vaikas
     members:


### PR DESCRIPTION
Fixes #954

I'm also removing `julz` from the admin memberships, and switching him to a normal member.

Note that I'm _not_ adding them to any teams right now (including the "admin" teams), because I think they may need to accept the org invite before being eligible to be added to teams, and Peribolos will complain if I try to do both steps at once.

I'm also not removing the `google` bots yet, but I expect that will probably happen one of these days.
