### PR TITLE
Remove skonto is not in org

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,7 +7,6 @@ aliases:
   autoscaling-reviewers:
   - nader-ziada
   - psschwei
-  - skonto
   - taragu
   autoscaling-wg-leads:
   - julz
@@ -172,7 +171,6 @@ aliases:
   - evankanderson
   - julz
   serving-observability-reviewers:
-  - skonto
   - yanweiguo
   serving-observability-writers:
   - yanweiguo
@@ -182,7 +180,6 @@ aliases:
   - nader-ziada
   - nealhu
   - psschwei
-  - skonto
   - whaught
   serving-writers:
   - dprotaso


### PR DESCRIPTION
unblocks https://github.com/knative-sandbox/knobots/pull/163

```
skonto
User is not a member of the org. User is not a collaborator. Satisfy at least one of these conditions to make the user trusted.
```