### PR TITLE
Remove skonto, not in org

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,7 +7,6 @@ aliases:
   autoscaling-reviewers:
   - nader-ziada
   - psschwei
-  - skonto
   - taragu
   autoscaling-wg-leads:
   - julz
@@ -172,7 +171,6 @@ aliases:
   - evankanderson
   - julz
   serving-observability-reviewers:
-  - skonto
   - yanweiguo
   serving-observability-writers:
   - yanweiguo
@@ -182,7 +180,6 @@ aliases:
   - nader-ziada
   - nealhu
   - psschwei
-  - skonto
   - whaught
   serving-writers:
   - dprotaso

--- a/knative-sandbox-OWNERS_ALIASES
+++ b/knative-sandbox-OWNERS_ALIASES
@@ -221,13 +221,11 @@ aliases:
   - JRBANCEL
   - ZhiminXiang
   - nak3
-  - skonto
   - tcnghia
   - vagababov
   net-kourier-approvers:
   - davidor
   - jmprusi
-  - skonto
   - tcnghia
   networking-wg-leads:
   - ZhiminXiang

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -229,7 +229,6 @@ orgs:
     - shrajfr12
     - shreejad
     - skim1420
-    - skonto
     - smarterclayton
     - smoser-ibm
     - snneji
@@ -1219,7 +1218,6 @@ orgs:
         members:
         - JRBANCEL
         - nak3
-        - skonto
         - tcnghia
         - vagababov
         - ZhiminXiang
@@ -1232,5 +1230,4 @@ orgs:
         members:
         - davidor
         - jmprusi
-        - skonto
         - tcnghia

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -435,7 +435,6 @@ orgs:
     - sixolet
     - sjug
     - skim1420
-    - skonto
     - slwilliams
     - smarterclayton
     - smoser-ibm
@@ -714,7 +713,6 @@ orgs:
         - taragu
         - psschwei
         - nader-ziada
-        - skonto
       Autoscaling Writers:
         description: Approvers and write access for autoscaling-related repositories.
         privacy: closed
@@ -1029,7 +1027,6 @@ orgs:
         description: Receive reviews for serving observability directories
         privacy: closed
         members:
-        - skonto
         teams:
           Serving Observability Writers:
             description: Approve serving observability code
@@ -1046,7 +1043,6 @@ orgs:
         - nealhu
         - carlisia
         - nader-ziada
-        - skonto
       Serving Writers:
         description: Grants write access to serving-related repositories.
         privacy: closed


### PR DESCRIPTION
Unblocks https://github.com/knative-sandbox/knobots/pull/163

```
- skonto
-- User is not a member of the org. User is not a collaborator. Satisfy at least one of these conditions to make the user trusted.
```