### PR TITLE
Clean up GSuite groups

### DIFF
--- a/groups/committee-oversight/groups.yaml
+++ b/groups/committee-oversight/groups.yaml
@@ -9,14 +9,10 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - evankanderson@knative.team
       - rhuss@knative.team
+      - rhuss@redhat.com
+      - evankanderson@knative.team
       - evana@vmware.com
       - evan.k.anderson@gmail.com
       - dprotaso@gmail.com
       - n3wscott@knative.team
-      - rhuss@redhat.com
-    members:
-      - mattmoor@knative.team
-      - grantr@knative.team
-      - markusthoemmes@knative.team

--- a/groups/committee-trademark/groups.yaml
+++ b/groups/committee-trademark/groups.yaml
@@ -7,9 +7,11 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - evana@vmware.com
-      - duglin@gmail.com
+      # VMware
       - evankanderson@knative.team
+      - evana@vmware.com
+      # IBM / RedHat
       - sdmoser@googlemail.com
       - SMOSER@de.ibm.com
+      # Google
       - spencerdillard@google.com

--- a/groups/wg-productivity/groups.yaml
+++ b/groups/wg-productivity/groups.yaml
@@ -65,11 +65,11 @@ groups:
       AllowExternalMembers: "true"
       ReconcileMembers: "true"
     owners:
-      - evana@gcp.vmware.com
+      - evana@vmware.com
       - evankanderson@knative.team
-      - markusthoemmes@gmail.com
+      - dprotaso@gmail.com
       - mattmoor@knative.team
       - mattomata@gmail.com
-      - tcnghia@gmail.com
+      - n3wscott@knative.team
     managers:
       - chizhg@google.com

--- a/groups/wg-productivity/groups.yaml
+++ b/groups/wg-productivity/groups.yaml
@@ -65,11 +65,11 @@ groups:
       AllowExternalMembers: "true"
       ReconcileMembers: "true"
     owners:
-      - evana@vmware.com
+      - evana@gcp.vmware.com
       - evankanderson@knative.team
-      - dprotaso@gmail.com
+      - markusthoemmes@gmail.com
       - mattmoor@knative.team
       - mattomata@gmail.com
-      - n3wscott@knative.team
+      - tcnghia@gmail.com
     managers:
       - chizhg@google.com


### PR DESCRIPTION
Looking at the declared GSuite groups, they seem to include a number of former members. Remove them (and add more current TOC members to the wg-productivity list).

/assign @dprotaso 

since he noticed it
