### PR TITLE
Update productivity group membership

### DIFF
--- a/groups/wg-productivity/OWNERS
+++ b/groups/wg-productivity/OWNERS
@@ -2,6 +2,7 @@
 
 approvers:
 - productivity-writers
+- technical-oversight-committee
 reviewers:
 - productivity-writers
 - productivity-reviewers

--- a/groups/wg-productivity/groups.yaml
+++ b/groups/wg-productivity/groups.yaml
@@ -65,11 +65,11 @@ groups:
       AllowExternalMembers: "true"
       ReconcileMembers: "true"
     owners:
-      - evana@gcp.vmware.com
+      - evana@vmware.com
       - evankanderson@knative.team
-      - markusthoemmes@gmail.com
+      - dprotaso@gmail.com
       - mattmoor@knative.team
       - mattomata@gmail.com
-      - tcnghia@gmail.com
+      - n3wscott@knative.team
     managers:
       - chizhg@google.com


### PR DESCRIPTION
Many of the `wg-productivity` members listed are not currently working on Knative. Sub in new TOC members to the list instead (though we might consider removing them until they need the access -- it's unclear what the emergency fix scenario might be without them having this access).

Add TOC as permitted to manage wg-productivity memberships.
