### PR TITLE
Add Matt as TOC Member, clarified TOC election rules

### DIFF
--- a/TECH-OVERSIGHT-COMMITTEE.md
+++ b/TECH-OVERSIGHT-COMMITTEE.md
@@ -96,7 +96,7 @@ The current members of the TOC are shown below.
 | -------------------------------------------------------------- | ---------------- | ---------- | ---------------------------------------------------- | ---------- | --------
 | <img width="30px" src="https://github.com/dprotaso.png">       | Dave Protasowski | VMware     | [@dprotaso](https://github.com/dprotaso)             | 2021-05-26 | 2022     |
 | <img width="30px" src="https://github.com/evankanderson.png">  | Evan Anderson    | VMware     | [@evankanderson](https://github.com/evankanderson)   | Bootstrap  | 2023     |
-| <img width="30px" src="https://github.com/mattmoor.png">       | Matt Moore       | Chainguard | [@mattmoor](https://github.com/mattmoor)             | 2022-01-13 | 2022     |
+| <img width="30px" src="https://github.com/mattmoor.png">       | Matt Moore       | Chainguard | [@mattmoor](https://github.com/mattmoor)             | 2022-02-07 | 2022     |
 | <img width="30px" src="https://github.com/n3wscott.png">       | Scott Nichols    | Chainguard | [@n3wscott](https://github.com/n3wscott)             | 2022-01-11 | 2022     |
 | <img width="30px" src="https://github.com/rhuss.png">          | Roland Huß       | Red Hat    | [@rhuss](https://github.com/rhuss)                   | 2021-02-16 | 2022     |
 
@@ -111,7 +111,7 @@ To recognize the folks that have served in the TOC in the past, below we list th
 | <img width="30px" src="https://github.com/mattmoor.png">       | Matt Moore      | [@mattmoor](https://github.com/mattmoor)             | Bootstrap  | 2021       |
 | <img width="30px" src="https://github.com/grantr.png">         | Grant Rodgers   | [@grantr](https://github.com/grantr)                 | 2020       | 2021       |
 | <img width="30px" src="https://github.com/markusthoemmes.png"> | Markus Thömmes  | [@markusthoemmes](https://github.com/markusthoemmes) | 2020-06-09 | 2021-12-16 |
-| <img width="30px" src="https://github.com/julz.png">           | Julian Friedman | [@julz](https://github.com/julz)                     | 2021-05-26 | 2022-01-13 |
+| <img width="30px" src="https://github.com/julz.png">           | Julian Friedman | [@julz](https://github.com/julz)                     | 2021-05-26 | 2022-02-07 |
 
 ---
 

--- a/TECH-OVERSIGHT-COMMITTEE.md
+++ b/TECH-OVERSIGHT-COMMITTEE.md
@@ -96,7 +96,7 @@ The current members of the TOC are shown below.
 | -------------------------------------------------------------- | ---------------- | ---------- | ---------------------------------------------------- | ---------- | --------
 | <img width="30px" src="https://github.com/dprotaso.png">       | Dave Protasowski | VMware     | [@dprotaso](https://github.com/dprotaso)             | 2021-05-26 | 2022     |
 | <img width="30px" src="https://github.com/evankanderson.png">  | Evan Anderson    | VMware     | [@evankanderson](https://github.com/evankanderson)   | Bootstrap  | 2023     |
-| <img width="30px" src="https://github.com/julz.png">           | Julian Friedman  | IBM        | [@julz](https://github.com/julz)                     | 2021-05-26 | 2023     |
+| <img width="30px" src="https://github.com/mattmoor.png">       | Matt Moore       | Chainguard | [@mattmoor](https://github.com/mattmoor)             | 2022-01-13 | 2022     |
 | <img width="30px" src="https://github.com/n3wscott.png">       | Scott Nichols    | Chainguard | [@n3wscott](https://github.com/n3wscott)             | 2022-01-11 | 2022     |
 | <img width="30px" src="https://github.com/rhuss.png">          | Roland Huß       | Red Hat    | [@rhuss](https://github.com/rhuss)                   | 2021-02-16 | 2022     |
 
@@ -104,13 +104,14 @@ The current members of the TOC are shown below.
 
 To recognize the folks that have served in the TOC in the past, below we list the previous members of the TOC (sorted by their 'Term End').
 
-| &nbsp;                                                         | Member         | Profile                                              | Term Start | Term End   |
-| -------------------------------------------------------------- | -------------- | ---------------------------------------------------- | ---------- | ---------- |
-| <img width="30px" src="https://github.com/vaikas.png">         | Ville Aikas    | [@vaikas](https://github.com/vaikas)                 | Bootstrap  | 2020       |
-| <img width="30px" src="https://github.com/tcnghia.png">        | Nghia Tran     | [@tcnghia](https://github.com/tcnghia)               | 2020       | 2021       |
-| <img width="30px" src="https://github.com/mattmoor.png">       | Matt Moore     | [@mattmoor](https://github.com/mattmoor)             | Bootstrap  | 2021       |
-| <img width="30px" src="https://github.com/grantr.png">         | Grant Rodgers  | [@grantr](https://github.com/grantr)                 | 2020       | 2021       |
-| <img width="30px" src="https://github.com/markusthoemmes.png"> | Markus Thömmes | [@markusthoemmes](https://github.com/markusthoemmes) | 2020-06-09 | 2021-12-16 |
+| &nbsp;                                                         | Member          | Profile                                              | Term Start | Term End   |
+| -------------------------------------------------------------- | ---------------  | --------------------------------------------------- | ---------- | ---------- |
+| <img width="30px" src="https://github.com/vaikas.png">         | Ville Aikas     | [@vaikas](https://github.com/vaikas)                 | Bootstrap  | 2020       |
+| <img width="30px" src="https://github.com/tcnghia.png">        | Nghia Tran      | [@tcnghia](https://github.com/tcnghia)               | 2020       | 2021       |
+| <img width="30px" src="https://github.com/mattmoor.png">       | Matt Moore      | [@mattmoor](https://github.com/mattmoor)             | Bootstrap  | 2021       |
+| <img width="30px" src="https://github.com/grantr.png">         | Grant Rodgers   | [@grantr](https://github.com/grantr)                 | 2020       | 2021       |
+| <img width="30px" src="https://github.com/markusthoemmes.png"> | Markus Thömmes  | [@markusthoemmes](https://github.com/markusthoemmes) | 2020-06-09 | 2021-12-16 |
+| <img width="30px" src="https://github.com/julz.png">           | Julian Friedman | [@julz](https://github.com/julz)                     | 2021-05-26 | 2022-01-13 |
 
 ---
 

--- a/mechanics/TOC.md
+++ b/mechanics/TOC.md
@@ -85,8 +85,10 @@ be held as soon as possible. Eligible voters from the most recent election will
 vote in the special election (ie: eligibility will not be redetermined at the
 time of the special election). 
 
-Any replacement TOC member will serve out the remainder of the term for the person 
-they are replacing, regardless of the length of that remainder.
+Any replacement TOC member who was appointed more than three months
+before the next TOC election will serve out the remainder of the term for
+the person they are replacing, regardless of the length of that
+remainder.
 
 ---
 


### PR DESCRIPTION
According to the Steering Committee Decision from [2021-01-13](https://docs.google.com/document/d/16Rpd2nhmLWrkFJUfpJ31Ox2PpultJ-bYIhqaiWQff_I/edit#bookmark=id.xjuz3b7bsrv1), Matt replaces Julz as TOC member until the end of the Term 2022.

Also, clarified in the TOC election rules, that a TOC replacement's within the last 3 months to an election lasts only until this election.
