### PR TITLE
Remove aryann from the knative peribolos config

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -57,7 +57,6 @@ orgs:
     - arghya88
     - ariel-bentu
     - arturenault
-    - aryann
     - asaksena
     - asciimike
     - aslakknutsen


### PR DESCRIPTION
The GitHub user updated their username and caused peribolos to fail, see the context in https://github.com/knative/test-infra/issues/3247.

For now removing them to unblock peribolos.

/cc @dprotaso @evankanderson 