### PR TITLE
Add @RamyChaabane to sandbox members

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -206,6 +206,7 @@ orgs:
     - rafaeltello
     - rakesh-garimella
     - RamXX
+    - RamyChaabane
     - rfranzke
     - ricardozanini
     - richterdavid


### PR DESCRIPTION
This patch adds @RamyChaabane to knative-sandbox members.

@RamyChaabane is actively contributing on net-kourier repo and has already several commits.
Please see: https://github.com/knative-sandbox/net-kourier/commits?author=RamyChaabane

His contribution has already meet the [member requirements](https://github.com/knative/community/blob/main/ROLES.md#requirements).

Note, I have already gotten the consent from @RamyChaabane on Slack about adding him to the members.
