### PR TITLE
docs: remove old CoC info from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-_Important_. Before proceeding, please review the Knative community
-[Code of Conduct](./CODE-OF-CONDUCT.md).
-
-If you any have questions or concerns, please contact the authors at
-knative-code-of-conduct@googlegroups.com.
-
 ## Welcome!
 
 Welcome to the Knative community!


### PR DESCRIPTION
See also https://github.com/knative/community/issues/968#issuecomment-1102855282

Do we continue to monitor the knative email for CoC reporting? Or is this all in CNCF hands now?