### PR TITLE
Several updates with minor changes to the TOC election process

### DIFF
--- a/mechanics/SC.md
+++ b/mechanics/SC.md
@@ -51,7 +51,7 @@ commenting on docs, helping people on slack, participating in working
 groups, actively promoting the Knative project, running project events, and
 anything else that helps the Knative project succeed and grow.
 
-[This dashboard](https://knative.teststats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year)
+[This dashboard](https://knative.devstats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year)
 shows only GitHub based contributions and does not capture all the contributions
 we value. _We expect this metric not to capture everyone who should be eligible
 to vote._ If a community member has had significant contributions over the past
@@ -60,8 +60,8 @@ to submit an exception form to the steering committee who will then review and
 determine whether this member should be marked as an exception.
 
 All eligible voters will be captured at
-`knative/community/elections/$YEAR/SC/voters.md` and the voters’ guide
-will be captured at `knative/community/elections/$YEAR/SC/README.md`
+`knative/community/elections/$YEAR-SC/voters.yaml` and the voters’ guide
+will be captured at `knative/community/elections/$YEAR-SC/README.md`
 similar to the kubernetes election process.
 
 We are committed to an inclusive process and will adapt future eligibility

--- a/mechanics/TOC.md
+++ b/mechanics/TOC.md
@@ -39,7 +39,7 @@ and commenting on PRs, opening and commenting on issues, writing design docs,
 commenting on design docs, helping people on slack, participating in working
 groups and etc.
 
-[This dashboard](https://knative.teststats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year)
+[This dashboard](https://knative.devstats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year)
 shows only GitHub based contributions and does not capture all the contributions
 we value. _We expect this metric not to capture everyone who should be eligible
 to vote._ If a community member has had significant contributions over the past
@@ -48,8 +48,8 @@ to submit an exception form to the steering committee who will then review and
 determine whether this member should be marked as an exception.
 
 All eligible voters will be captured at
-`knative/community/elections/$YEAR/TOC/voters.md` and the voters’ guide
-will be captured at `knative/community/elections/$YEAR/TOC/README.md`
+`knative/community/elections/$YEAR-TOC/voters.yaml` and the voters’ guide
+will be captured at `knative/community/elections/$YEAR-TOC/README.md`
 similar to the kubernetes election process.
 
 We are committed to an inclusive process and will adapt future eligibility
@@ -65,7 +65,8 @@ the open seats.
 ## Election Officers
 
 The steering committee will be the election officers for the technical oversight
-committee elections.
+committee elections, or they may delegate this responsibility and appoint
+election officers.
 
 ## Vacancies
 


### PR DESCRIPTION
Changes include:

* Updated the devstats link for voter eligibility now that we are under the main CNCF devstats instance
* updated the format of the election directories to match the format used by Elekto
* added a note that the steering committee may delegate election officer duties for the TOC since that is what we have been doing for the past 2 elections.