### PR TITLE
Add @cncf-ci to Knative Community

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -69,6 +69,7 @@ orgs:
     - chizhg
     - christophd
     - chunyilyu
+    - cncf-ci
     - cooperneil
     - coryrc
     - cr22rc

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -110,6 +110,7 @@ orgs:
     - chunyilyu
     - cjwagner
     - cloudrobx
+    - cncf-ci
     - cooperneil
     - coryrc
     - cppforlife


### PR DESCRIPTION
This bot will be part of the CNCF Community Infrastructure team tooling. No changes will be introduced to the project via this bot, only strategic observations and suggestions.