### PR TITLE
Add Paul as TOC candidate

### DIFF
--- a/elections/2022-TOC/candidate-psschwei.md
+++ b/elections/2022-TOC/candidate-psschwei.md
@@ -3,6 +3,7 @@ name: Paul Schweigert
 ID: psschwei
 info:
   - affiliation: IBM
+  - owners: Docs, Productivity
 -------------------------------------------------------------
 
 Hi, I'm Paul. I've been involved in a number of areas in the Knative project since I joined the

--- a/elections/2022-TOC/candidate-psschwei.md
+++ b/elections/2022-TOC/candidate-psschwei.md
@@ -1,0 +1,20 @@
+------------------------------------------------------------
+name: Paul Schweigert
+ID: psschwei
+info:
+  - affiliation: IBM
+-------------------------------------------------------------
+
+Hi, I'm Paul. I've been involved in a number of areas in the Knative project since I joined the
+community. I'm most active in Autoscaling, where I built the Container Freezer functionality and
+am more generally working on various ways to reduce cold start latencies. I'm a frequent
+contributor to the Serving and Docs/User Experience areas; have done more focused work on client plugins,
+productivity, and security; and am an approver and/or reviewer for multiple areas. I was also a
+release lead for the 1.3 release.
+
+What I love about Knative is how much easier it makes it for developers to run their applications on
+Kubernetes. I'm running for the TOC for two main reasons: (1) to help carry that message out to the broader
+community and to help grow the project (both in terms of features and contributors) over the course of my
+term, and (2) to use my experience to help focus on areas like performance that ensure Knative continues to
+meet the needs of our userbase.
+


### PR DESCRIPTION
Hi, I'm Paul. I've been involved in a number of areas in the Knative project since I joined the
community. I'm most active in Autoscaling, where I built the Container Freezer functionality and
am more generally working on various ways to reduce cold start latencies. I'm a frequent
contributor to the Serving and Docs/User Experience areas; have done more focused work on client plugins,
productivity, and security; and am an approver and/or reviewer for multiple areas. I was also a
release lead for the 1.3 release.

What I love about Knative is how much easier it makes it for developers to run their applications on
Kubernetes. I'm running for the TOC for two main reasons: (1) to help carry that message out to the broader
community and to help grow the project (both in terms of features and contributors) over the course of my
term, and (2) to use my experience to help focus on areas like performance that ensure Knative continues to
meet the needs of our userbase.