### PR TITLE
Fixed links to Elekto

### DIFF
--- a/elections/2022-TOC/README.md
+++ b/elections/2022-TOC/README.md
@@ -149,5 +149,5 @@ the [TOC Election Charter].
 
 [Eligibility for candidacy]: https://github.com/knative/community/blob/master/mechanics/TOC.md#candidate-eligibility
 [Eligibility for voting]: https://github.com/knative/community/blob/master/mechanics/TOC.md#candidate-eligibility#voter-eligibility
-[Elekto]: https://test.elekto.io
-[file a voting exception]: https://test.elekto.io/app/elections/2022-TOC/exception
+[Elekto]: https://elections.knative.dev
+[file a voting exception]: https://elections.knative.dev/app/elections/2022-TOC/exception

--- a/elections/2022-TOC/election_desc.md
+++ b/elections/2022-TOC/election_desc.md
@@ -11,7 +11,7 @@ This is a brief summary of the election; for more details, such as how to become
 
 ## Eligibility
 
-All Knative contributors with [50 or more contributions](https://knative.devstats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year) over the last year are eligible to vote.  You will see either ELIGIBLE or NOT ELIGIBLE at the top of this screen.  If you are not eligible, but should be, please [file an exception request](https://test.elekto.io/app/elections/2022-TOC/exception) or contact elections@knative.team.
+All Knative contributors with [50 or more contributions](https://knative.devstats.cncf.io/d/9/developer-activity-counts-by-repository-group-table?orgId=1&var-period_name=Last%20year) over the last year are eligible to vote.  You will see either ELIGIBLE or NOT ELIGIBLE at the top of this screen.  If you are not eligible, but should be, please [file an exception request](https://elections.knative.dev/app/elections/2022-TOC/exception) or contact elections@knative.team.
 
 ### Schedule
 


### PR DESCRIPTION
I didn't realize that we'd moved the knative instance of Elekto to https://elections.knative.dev/ from the test instance, so I've fixed all of the links in the README and election_desc used within Elekto.