### PR TITLE
Add OWNERS file field to candidates template

### DIFF
--- a/elections/2022-TOC/election.yaml
+++ b/elections/2022-TOC/election.yaml
@@ -6,7 +6,8 @@ no_winners: 4
 allow_no_opinion: True
 delete_after: True
 show_candidate_fields:
-  - employer
+  - affiliation
+  - owners
 election_officers:
   - geekygirldawn
   - jberkus

--- a/elections/2022-TOC/nomination-template.md
+++ b/elections/2022-TOC/nomination-template.md
@@ -3,6 +3,7 @@ name: Your Name
 ID: GithubID
 info:
   - affiliation: Employer or other org affiliation
+  - owners: an owners file you're an approver in
 -------------------------------------------------------------
 
 Here's a paragraph about my contributions to Knative.


### PR DESCRIPTION
 ... per discussion with Steering on Slack.

This elections configuration update does two things:

1. Configures "affiliations" and "owners" fields as the visible fields on candidate profiles
2. Adds an "owners" field to the candidate profile

Reason: being named as an Approver in one or more Owners files is a requirement to run for TOC.  Since there is no master index of Owners files for Knative, EOs and voters need this info to validate candidate eligibility.


