### PR TITLE
Create a Functions WG

### DIFF
--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -59,6 +59,7 @@ The current working groups are:
   - [Documentation + User Experience](#documentation--user-experience)
   - [Eventing](#eventing)
   - [Eventing Kafka](#eventing-kafka)
+  - [Functions](#functions)
   - [Networking](#networking)
   - [Operations](#operations)
   - [Productivity](#productivity)
@@ -215,6 +216,27 @@ A dedicated working group for Kafka-based Knative Eventing components.
 | <img width="30px" src="https://github.com/devguyio.png">       | Ahmed Abdalla   | [devguyio](https://github.com/devguyio)             | 2021-2022 |
 | <img width="30px" src="https://github.com/lionelvillard.png">  | Lionel Villard  | [lionelvillard](https://github.com/lionelvillard)   | 2021-2022 |
 
+
+## Functions
+
+Knative Functions [CLI](https://github.com/knative-sandbox/kn-plugin-func), API, and [language packs](https://github.com/knative-sandbox/func-tastic)
+
+| Artifact                   | Link                                                                                                                     |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------|
+| Charter / Mission          | [Charter](https://docs.google.com/document/d/1rwRt4Hi27Jgoqg8wK6tmtVZJdxOFheQei-_Wx3KPsQc/edit?usp=sharing)                                                                              |
+| Roadmap                    | [Roadmap](https://github.com/orgs/knative-sandbox/projects/7)                                                            |
+| Forum                      | [knative-dev@](https://groups.google.com/forum/#!forum/knative-dev)                                                      |
+| Community Meeting VC       | See the top of the [Meeting notes](https://docs.google.com/document/d/1zydqnsw2ty5siL_FT2U7klMTK7OuKWRZNmkUJMx3cWE/edit?usp=sharing)
+| Community Meeting Calendar | Tuesdays 10:00a-10:30a EDT <br>[Calendar](https://calendar.google.com/calendar/embed?src=knative.team_9q83bg07qs5b9rrslp5jor4l6s%40group.calendar.google.com)|
+| Meeting Notes              | [Notes](https://docs.google.com/document/d/1zydqnsw2ty5siL_FT2U7klMTK7OuKWRZNmkUJMx3cWE/edit?usp=sharing)                            |
+| Document Folder            | [Folder](https://drive.google.com/drive/folders/1Ebe9blQDgDjFOylqAtUe85UNecEfOzes?usp=sharing)                           |
+| Slack Channel              | [#functions-sandbox](https://slack.knative.dev/messages/functions-sandbox)                                                     |
+| Github Team WG leads       | [@knative/func-wg-leads](https://github.com/orgs/knative/teams/func-wg-leads/members)                                                                       |
+
+| &nbsp;                                                           | Leads           | Company | Profile                                           |
+| ---------------------------------------------------------------- | --------------- | ------- | ------------------------------------------------- |
+| <img width="30px" src="https://github.com/lance.png"> | Lance Ball    | Red Hat     | [lance](https://github.com/lance) |
+| <img width="30px" src="https://github.com/salaboy.png"> | Mauricio Salatino    | VMWare     | [salaboy](https://github.com/salaboy) |
 
 ## Networking
 

--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -223,7 +223,7 @@ Knative Functions [CLI](https://github.com/knative-sandbox/kn-plugin-func), API,
 
 | Artifact                   | Link                                                                                                                     |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------|
-| Charter / Mission          | [Charter](https://docs.google.com/document/d/1rwRt4Hi27Jgoqg8wK6tmtVZJdxOFheQei-_Wx3KPsQc/edit?usp=sharing)                                                                              |
+| Charter / Mission          | [Charter](https://github.com/lance/community/blob/add-func-wg/working-groups/functions/CHARTER.md)                                                                              |
 | Roadmap                    | [Roadmap](https://github.com/orgs/knative-sandbox/projects/7)                                                            |
 | Forum                      | [knative-dev@](https://groups.google.com/forum/#!forum/knative-dev)                                                      |
 | Community Meeting VC       | See the top of the [Meeting notes](https://docs.google.com/document/d/1zydqnsw2ty5siL_FT2U7klMTK7OuKWRZNmkUJMx3cWE/edit?usp=sharing)

--- a/working-groups/functions/CHARTER.md
+++ b/working-groups/functions/CHARTER.md
@@ -1,0 +1,37 @@
+# Functions WG Charter
+
+Drafted: Apr 28, 2022
+
+## Mission
+The Functions Working Group aims to simplify application development and deployment to Knative by transforming business logic written as a programming language function into OCI container images, and creating or updating the associated on-cluster resources.
+
+By providing higher-level abstractions through functions, the working group aims to make Knative accessible for developers without extensive Kubernetes or container experience.
+
+## Goals
+- Provide a developer experience enabling portable, high-level business logic in several programming languages in the form of a “Function” as a Knative Service.
+- Provide Function invocation, HTTP serving and CloudEvent marshaling capabilities through language frameworks, capable of wrapping and bootstrapping Knative Function code into a runnable service.
+- Provide a developer experience that enables the build and deployment of Knative Functions as OCI container images in a Knative Service.
+- Define and document a pluggable ‘language pack’ contract to adapt developer code to the Knative runtime contract.
+  - Additionally, curate a set of language plugins which are recommended to new developers.
+- Implement a shared CLI which provides commands for creation, build, iteration, and deployment of Knative Services using language plugins.
+  - The shared CLI should be as broadly useful as possible, supporting both local and remote build tooling.
+
+## Non-Goals
+- Provide a general-purpose client which duplicates the functionality of kn.
+- Implement language plugins for all programming languages.
+
+## Scope
+- Defining and implementing the interface between developers and the functions CLI.
+  - Including command-line options, UX flow, supported commands, source directory requirements, etc.
+- Defining and supporting the language plugin interface.
+  - This includes developing and supporting third-party language plugin authors as well as first-party language plugins.
+  - This also includes any “catalog” or “template” management and shared services provided to language plugins via the CLI or on-cluster build interfaces.
+- Providing examples and coordinating with the documentation WG to provide user-facing examples and documentation on using the function tools.
+
+## Initial Leads
+- Lance Ball - Red Hat
+- Mauricio Salatino - VMWare
+
+## Roadmap
+https://github.com/orgs/knative-sandbox/projects/7
+


### PR DESCRIPTION
# Changes

Adds Functions as a distinct working group outside of the Client. It does not remove existing peribolos settings for kn-plugin-func.

## Steps outlined in mechanics/WORKING-GROUP-PROCESSES.md

- [x] **Create a Google Drive Folder**. Create a folder to hold your working group documents within this parent [folder](https://drive.google.com/drive/folders/0AM-QGZJ-HUA8Uk9PVA).  Call your folder "GROUP_NAME".
- [x] **Create a Meeting Notes Document**. Create a blank document in the above folder and call it "GROUP_NAME Group Meeting Notes".
- [x] **Create a Roadmap**. Create a new [Roadmap Project Board](https://github.com/knative/community/blob/main/mechanics/ROADMAPS.md).
- [x] **Schedule a Recurring Meeting**. Create a recurring meeting (weekly or bi-weekly, 30 or 60 minutes) on the [shared calendar](https://calendar.google.com/calendar/u/0/embed?src=knative.team_9q83bg07qs5b9rrslp5jor4l6s@group.calendar.google.com) and call the meeting "\$GROUP_NAME WG". Attach the meeting notes document to  the calendar event. Generally schedule these meetings between 9:00AM to 2:59PM Pacific Time. Invite `knative-dev@googlegroups.com` Google group to the  meeting, as well as necessary individual participants.
- [x] **Register the Working Group**. Go to  [WORKING-GROUPS.md](../working-groups/WORKING-GROUPS.md) and add your working  group name, the names of the leads, the working group charter, and a link to the meeting you created.
- [x] **Create Github Team using Peribolos**. Go to [peribolos/knative.md](../peribolos/knative.md), add your working group name under teams, and members. Grant access to relevant repositories for the working group.
- [x] **Announce your Working Group**. Send a note to [knative-dev@](mailto:knative-dev@googlegroups.com),  [knative-tech-oversight@](mailto:knative-tech-oversight@googlegroups.com), and  [steering@](mailto:steering@knative.team) to announce your new working group. Include your charter in the email and provide links to the meeting invitation.
