### PR TITLE
Adding Scott as 2022 TOC candidate

### DIFF
--- a/elections/2022-TOC/canidate-n3wscott.md
+++ b/elections/2022-TOC/canidate-n3wscott.md
@@ -1,0 +1,24 @@
+-------------------------------------------------------------
+name: Scott Nichols
+ID: n3wscott
+
+info:
+  - affiliation: Chainguard, Inc.
+  - owners: Current TOC
+-------------------------------------------------------------
+
+I have been contributing to Knative since initial public launch. In that time I
+held the role of Sources Working Group Lead, as well leading the Productivity
+Working Group during a time of uncertainty. I was a core contributor to Eventing
+and was also a key member reconciler framework and generator code. I am a
+maintainer on the CloudEvents Go SDK, a foundational component of Eventing. I
+have most recently been serving on the Knative TOC, and helped in the planning
+committee with our very first KnCon Day Zero event (!!!HYPE!!!).
+
+I care deeply about the direction and future of Knative as a project. It is
+vitally important to continue the work we are doing in Knative to level the
+playing field for all of the Cloud Native landscape to make Cloud Computing more
+accessible to those who want to provide business value on-top of an already
+complex landscape. I want to provide a voice for Knative from the prospective of
+a small business whose mission is not directly related to Knative, but Knative is
+that enabling technology to let us move fast in the real world.


### PR DESCRIPTION
Hello! I am Scott.

I have been contributing to Knative since initial public launch. In that time I
held the role of Sources Working Group Lead, as well leading the Productivity
Working Group during a time of uncertainty. I was a core contributor to Eventing
and was also a key member reconciler framework and generator code. I am a
maintainer on the CloudEvents Go SDK, a foundational component of Eventing. I
have most recently been serving on the Knative TOC, and helped in the planning
committee with our very first KnCon Day Zero event (!!!HYPE!!!).

I care deeply about the direction and future of Knative as a project. It is
vitally important to continue the work we are doing in Knative to level the
playing field for all of the Cloud Native landscape to make Cloud Computing more
accessible to those who want to provide business value on-top of an already
complex landscape. I want to provide a voice for Knative from the prospective of
a small business whose mission is not directly related to Knative, but Knative is
that enabling technology to let us move fast in the real world.