### PR TITLE
Add dprotaso as 2022 TOC Candidate 

### DIFF
--- a/elections/2022-TOC/candidate-dprotaso.md
+++ b/elections/2022-TOC/candidate-dprotaso.md
@@ -1,0 +1,15 @@
+-------------------------------------------------------------
+name: David Protasowski
+ID: dprotaso
+info:
+  - affiliation: VMware
+  - owners: Serving
+-------------------------------------------------------------
+
+Hey everyone. I'm a current TOC member and Serving Lead. I've been contributing 
+to the project (in many of it's areas) since 2017 - before it was called Knative. 
+
+With the CNCF donation we're at an exciting step in the project's journey. I'm seeing
+more engagement from end-users and new contributors. This year I hope to support 
+existing WG leads and to help new contributors onboard onto the project.
+


### PR DESCRIPTION
Hey everyone. I'm a current TOC member and Serving Lead. I've been contributing 
to the project (in many of it's areas) since 2017 - before it was called Knative. 

 With the CNCF donation we're at an exciting step in the project's journey. I'm seeing
more engagement from end-users and new contributors. This year I hope to support 
existing WG leads and to help new contributors onboard onto the project.
