### PR TITLE
Add dsimansk as 2022 TOC candidate

### DIFF
--- a/elections/2022-TOC/candidate-dsimansk.md
+++ b/elections/2022-TOC/candidate-dsimansk.md
@@ -1,0 +1,19 @@
+-------------------------------------------------------------
+name: David Simansky
+ID: dsimansk
+info:
+  - affiliation: Red Hat
+  - owners: client
+-------------------------------------------------------------
+
+Hello everyone!
+
+I'm David. Currently I'm one of Client WG leads.
+I've started my Knative journey as an active contributor since the beginning of 2020, focusing mainly on the CLI and its plugins.
+Over time I was able to rank up through approver role to WG lead. From other areas I occasionally get involved in productivity/CI
+related issues, I kind of enjoy searching for a needle in the haystack.   
+
+
+The Knative client is the first point of contact for users and is at the heart of the Knative user experience. Also, it's a perfect starting point for new Knative contributors as it constantly offers some entry-level challenges.
+With the candidacy to TOC, I'd like to expand my reach in the community. There're two objectives I'd like to focus on. First to bring in the client-side perspective to the TOC as I think that a focus on the user experience should be a driving force for future visions of Knative. Secondly, to help
+with onboarding new contributors and facilitate collaboration across all the groups.


### PR DESCRIPTION
Hello everyone!

I'm David. Currently I'm one of Client WG leads.
I've started my Knative journey as an active contributor since the beginning of 2020, focusing mainly on the CLI and its plugins.
Over time I was able to rank up through approver role to WG lead. From other areas I occasionally get involved in productivity/CI
related issues, I kind of enjoy searching for a needle in the haystack.   


The Knative client is the first point of contact for users and is at the heart of the Knative user experience. Also, it's a perfect starting point for new Knative contributors as it constantly offers some entry-level challenges.
With the candidacy to TOC, I'd like to expand my reach in the community. There're two objectives I'd like to focus on. First to bring in the client-side perspective to the TOC as I think that a focus on the user experience should be a driving force for future visions of Knative. Secondly, to help
with onboarding new contributors and facilitate collaboration across all the groups.