### PR TITLE
Proposing that SC, TOC, and Trademark Committee members should be eligible to vote.

### DIFF
--- a/mechanics/SC.md
+++ b/mechanics/SC.md
@@ -59,6 +59,9 @@ year but is not captured in the stats.knative.dev dashboard, they will be able
 to submit an exception form to the steering committee who will then review and
 determine whether this member should be marked as an exception.
 
+Additionally, anyone serving on the SC, TOC, or Trademark Committee will 
+automatically be eligible to vote regardless of their number of contributions.
+
 All eligible voters will be captured at
 `knative/community/elections/$YEAR-SC/voters.yaml` and the voters’ guide
 will be captured at `knative/community/elections/$YEAR-SC/README.md`

--- a/mechanics/TOC.md
+++ b/mechanics/TOC.md
@@ -50,6 +50,9 @@ year but is not captured in the stats.knative.dev dashboard, they will be able
 to submit an exception form to the steering committee who will then review and
 determine whether this member should be marked as an exception.
 
+Additionally, anyone serving on the SC, TOC, or Trademark Committee will 
+automatically be eligible to vote regardless of their number of contributions.
+
 All eligible voters will be captured at
 `knative/community/elections/$YEAR-TOC/voters.yaml` and the voters’ guide
 will be captured at `knative/community/elections/$YEAR-TOC/README.md`


### PR DESCRIPTION
This PR adding that SC, TOC, and Trademark Committee members are eligible to vote regardless of the number of contributions for TOC and SC elections. Every year, we have several committee members who make significant contributions, but who don't hit the 50 devstats contributions. Rather than making them file exception requests for every election, I think we should just make them eligible by default.

This change requires SC approval. 

/hold