### PR TITLE
Remove antoineco

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -40,7 +40,6 @@ aliases:
   - tommyreddad
   eventing-triage:
   - akashrv
-  - antoineco
   - lberk
   eventing-wg-leads:
   - lionelvillard
@@ -48,7 +47,6 @@ aliases:
   eventing-writers:
   - akashrv
   - aliok
-  - antoineco
   - lberk
   - lionelvillard
   - matzew

--- a/peribolos/knative-sandbox-OWNERS_ALIASES
+++ b/peribolos/knative-sandbox-OWNERS_ALIASES
@@ -54,7 +54,6 @@ aliases:
   - lberk
   - matzew
   eventing-gitlab-approvers:
-  - antoineco
   - lberk
   - matzew
   - sebgoa

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -43,7 +43,6 @@ orgs:
     - andrew-su
     - AngeloDanducci
     - anishj0shi
-    - antoineco
     - arghya88
     - arturenault
     - aslakknutsen
@@ -930,7 +929,6 @@ orgs:
         repos:
           eventing-gitlab: write
         members:
-        - antoineco
         - lberk
         - sebgoa
         - tzununbekov

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -56,7 +56,6 @@ orgs:
     - anishj0shi
     - ankushchadha
     - anniefu
-    - antoineco
     - apolito
     - arghya88
     - ariel-bentu
@@ -796,7 +795,6 @@ orgs:
             members:
             - lberk
             - akashrv
-            - antoineco
             privacy: closed
           Eventing WG Leads:
             description: The Working Group leads for Eventing


### PR DESCRIPTION
# Changes

- 🧹 Remove `antoineco` from groups and owner aliases

I haven't been quite as active as I used to be lately and, because I will soon be pursuing new challenges where Knative is unfortunately not in the picture, now is my time to say good bye to all of you 👋
Working with Knative has always been a great pleasure for me. In fact, one of the main reasons for me to join TriggerMesh two years ago was to remain active in the project!
I wish you all a lot of success with Knative, it is certainly in very capable hands.

/kind cleanup
/kind deprecation (🥲)