### PR TITLE
Add @norbjd to sandbox members

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -189,6 +189,7 @@ orgs:
     - nealhu
     - nicolaferraro
     - nimbcode
+    - norbjd
     - novahe
     - nlopezgi
     - odacremolbap


### PR DESCRIPTION
This patch adds @norbjd to knative-sandbox members.

@norbjd is actively contributing on net-kourier repo and has already several commits.
Please see: 
- https://github.com/knative-sandbox/net-kourier/commits?author=norbjd

(also in eventing-natss)
- https://github.com/knative-sandbox/eventing-natss/issues/created_by/norbjd
- https://github.com/knative-sandbox/eventing-natss/pulls/norbjd

His contribution has already meet the [member requirements](https://github.com/knative/community/blob/main/ROLES.md#requirements).

Note, I have already gotten the consent from @norbjd on Slack about adding him to the members.
