### PR TITLE
Fix Error Wrapping Verb for go 1.18

### DIFF
--- a/groups/reconcile_test.go
+++ b/groups/reconcile_test.go
@@ -703,7 +703,7 @@ func TestReconcileGroups(t *testing.T) {
 			expectedState = c.desiredState
 		}
 		if err = s.isReconciled(expectedState); err != nil {
-			t.Errorf("reconciliation unsuccessful for case %s: %w", c.desc, err)
+			t.Errorf("reconciliation unsuccessful for case %s: %v", c.desc, err)
 		}
 	}
 }

--- a/groups/service_test.go
+++ b/groups/service_test.go
@@ -179,7 +179,7 @@ func TestAddOrUpdateGroupMembers(t *testing.T) {
 
 		adminSvc, err := NewAdminServiceWithClientAndErrFunc(fakeClient, errFunc)
 		if err != nil {
-			t.Errorf("error creating client %w", err)
+			t.Errorf("error creating client %v", err)
 		}
 		err = adminSvc.AddOrUpdateGroupMembers(c.g, c.role, c.members)
 		if err != nil {
@@ -188,7 +188,7 @@ func TestAddOrUpdateGroupMembers(t *testing.T) {
 
 		result, err := fakeClient.ListMembers(c.g.EmailId)
 		if err != nil {
-			t.Errorf("error while listing members for groupKey %s and case %s: %w", c.g.EmailId, c.desc, err)
+			t.Errorf("error while listing members for groupKey %s and case %s: %v", c.g.EmailId, c.desc, err)
 		}
 		if !checkForMemberListEquality(result, c.expectedMembers) {
 			t.Errorf("unexpected list of members for %s, expected: %#v, got: %#v",
@@ -250,7 +250,7 @@ func TestCreateOrUpdateGroupIfNescessary(t *testing.T) {
 
 		adminSvc, err := NewAdminServiceWithClientAndErrFunc(fakeClient, errFunc)
 		if err != nil {
-			t.Errorf("error creating client %w", err)
+			t.Errorf("error creating client %v", err)
 		}
 
 		err = adminSvc.CreateOrUpdateGroupIfNescessary(c.g)
@@ -260,7 +260,7 @@ func TestCreateOrUpdateGroupIfNescessary(t *testing.T) {
 
 		result, err := fakeClient.ListGroups()
 		if err != nil {
-			t.Errorf("error while listing groups for case %s: %w", c.desc, err)
+			t.Errorf("error while listing groups for case %s: %v", c.desc, err)
 		}
 
 		if !checkForGroupListEquality(result.Groups, c.expectedGroups) {
@@ -302,7 +302,7 @@ func TestDeleteGroupsIfNecessary(t *testing.T) {
 
 		adminSvc, err := NewAdminServiceWithClientAndErrFunc(fakeClient, errFunc)
 		if err != nil {
-			t.Errorf("error creating client %w", err)
+			t.Errorf("error creating client %v", err)
 		}
 		groupsConfig.Groups = c.desiredState
 
@@ -313,7 +313,7 @@ func TestDeleteGroupsIfNecessary(t *testing.T) {
 
 		result, err := fakeClient.ListGroups()
 		if err != nil {
-			t.Errorf("error while listing groups for case %s: %w", c.desc, err)
+			t.Errorf("error while listing groups for case %s: %v", c.desc, err)
 		}
 
 		if !checkForAdminGroupGoogleGroupEquality(result.Groups, c.desiredState) {
@@ -370,7 +370,7 @@ func TestRemoveOwnerOrManagersFromGroup(t *testing.T) {
 
 		adminSvc, err := NewAdminServiceWithClientAndErrFunc(fakeClient, errFunc)
 		if err != nil {
-			t.Errorf("error creating client %w", err)
+			t.Errorf("error creating client %v", err)
 		}
 
 		err = adminSvc.RemoveOwnerOrManagersFromGroup(c.g, c.desiredState)
@@ -380,7 +380,7 @@ func TestRemoveOwnerOrManagersFromGroup(t *testing.T) {
 
 		result, err := fakeClient.ListMembers(c.g.EmailId)
 		if err != nil {
-			t.Errorf("error while listing members for groupKey %s and case %s: %w", c.g.EmailId, c.desc, err)
+			t.Errorf("error while listing members for groupKey %s and case %s: %v", c.g.EmailId, c.desc, err)
 		}
 
 		if !checkForMemberListEquality(result, c.expectedMembers) {
@@ -436,7 +436,7 @@ func TestRemoveMembersFromGroup(t *testing.T) {
 
 		adminSvc, err := NewAdminServiceWithClientAndErrFunc(fakeClient, errFunc)
 		if err != nil {
-			t.Errorf("error creating client %w", err)
+			t.Errorf("error creating client %v", err)
 		}
 
 		err = adminSvc.RemoveMembersFromGroup(c.g, c.desiredState)
@@ -446,7 +446,7 @@ func TestRemoveMembersFromGroup(t *testing.T) {
 
 		result, err := fakeClient.ListMembers(c.g.EmailId)
 		if err != nil {
-			t.Errorf("error while listing members for groupKey %s and case %s: %w", c.g.EmailId, c.desc, err)
+			t.Errorf("error while listing members for groupKey %s and case %s: %v", c.g.EmailId, c.desc, err)
 		}
 
 		if !checkForMemberListEquality(result, c.expectedMembers) {
@@ -552,7 +552,7 @@ func TestUpdateGroupSettings(t *testing.T) {
 
 		groupSvc, err := NewGroupServiceWithClientAndErrFunc(fakeClient, errFunc)
 		if err != nil {
-			t.Errorf("error creating client %w", err)
+			t.Errorf("error creating client %v", err)
 		}
 
 		err = groupSvc.UpdateGroupSettings(c.g)
@@ -562,7 +562,7 @@ func TestUpdateGroupSettings(t *testing.T) {
 
 		result, err := fakeClient.Get(c.g.EmailId)
 		if err != nil {
-			t.Errorf("error while getting groupsettings of group with groupKey %s: %w", c.g.EmailId, err)
+			t.Errorf("error while getting groupsettings of group with groupKey %s: %v", c.g.EmailId, err)
 		}
 
 		if !reflect.DeepEqual(result, c.expectedSettings) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

There is a breaking change in go 1.18 that needs to be fixed.
Details: https://github.com/golang/go/issues/47641
Errors: #1090 

/cc @dprotaso 

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind c

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

<!-- Please include the 'why' behind your changes if no issue exists -->


<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
