### PR TITLE
Add new `admins@knative.dev` google group

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -73,3 +73,13 @@ groups:
       - vaikas@gmail.com
       - itsmurugappan@knative.team
 
+  - email-id: admins@knative.dev
+    name: admins
+    description: |-
+      Admins mailing group.
+    settings:
+      AllowExternalMembers: "false"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+    members:
+      - toc@knative.team
+      - steering@knative.team

--- a/groups/groups_test.go
+++ b/groups/groups_test.go
@@ -167,9 +167,8 @@ func TestDescriptionLength(t *testing.T) {
 func TestGroupConventions(t *testing.T) {
 	for _, g := range cfg.Groups {
 		// groups are easier to reason about if email and name match
-		expectedEmailId := g.Name + "@knative.team"
-		if g.EmailId != expectedEmailId {
-			t.Errorf("group '%s': expected email '%s', got '%s'", g.Name, expectedEmailId, g.EmailId)
+		if !(g.EmailId == g.Name+"@knative.team" || g.EmailId == g.Name+"@knative.dev") {
+			t.Errorf("group '%s': expected email '%s@knative.dev or %s@knative.team', got '%s'", g.Name, g.Name, g.Name, g.EmailId)
 		}
 	}
 }

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -25,4 +25,5 @@ restrictions:
     allowedGroups:
       - "^wg-leads@knative.team$"
       - "^calendar-maintainers@knative.team$"
+      - "^admins@knative.dev$"
   - path: "**/*" # prevent any other file from containing anything


### PR DESCRIPTION
I'm looking to verify our GitHub organization as per https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-organization-settings/verifying-or-approving-a-domain-for-your-organization.

As part of that, we can't have [knative-admins@googlegroups.com](mailto:knative-admins@googlegroups.com) address at https://github.com/knative as we don't own googlegroups.com. I made a new group and added steering and toc to it.

Also, mail delivery is now enabled on knative.dev so we can receive emails on that domain 🎉 

/cc @csantanapr 