### PR TITLE
Add github emails in Peribolos

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -2,7 +2,7 @@ orgs:
   knative-sandbox:
     name: Knative Sandbox
     description: Sandbox for projects that are part of the broader knative project
-    email: knative-admins@googlegroups.com
+    email: admins@knative.dev
     billing_email: knative@google.com
     company: ""
     location: ""

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -2,7 +2,7 @@ orgs:
   knative:
     description: Kubernetes-based platform to build, deploy, and manage modern serverless workloads
     name: Knative
-    email: knative-admins@googlegroups.com
+    email: admins@knative.dev
     has_organization_projects: true
     has_repository_projects: true
     members_can_create_repositories: false


### PR DESCRIPTION
I forgot that the emails were configured in peribolos.

Completing https://github.com/knative/community/pull/1101 and https://knative.slack.com/archives/CCSNR4FCH/p1656458028485489

/kind enhancement

/cc @dprotaso 