### PR TITLE
Update Trademark composition

### DIFF
--- a/TRADEMARK-COMMITTEE.md
+++ b/TRADEMARK-COMMITTEE.md
@@ -75,11 +75,11 @@ the trademark committee invites your feedback there. See
 
 ## Committee Members
 
-| Member                   | Organization | Profile                                              |
-| ------------------------ | ------------ | ---------------------------------------------------- |
-| Spencer Dillard          | Google       | [@spencerdillard](https://github.com/spencerdillard) |
-| Doug Davis               | IBM/RedHat   | [@duglin](https://github.com/duglin)                 |
-| Evan Anderson            | VMware       | [@evankanderson](https://github.com/evankanderson)   |
+| Member        | Organization | Profile                                            |
+| ------------- | ------------ | -------------------------------------------------- |
+| Mark Chmarny  | Google       | [@mchmarny](https://github.com/mchmarny)           |
+| Simon Moser   | IBM/RedHat   | [@smoser-ibm](https://github.com/smoser-ibm)       |
+| Evan Anderson | VMware       | [@evankanderson](https://github.com/evankanderson) |
 
 ## Decision process
 

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -322,6 +322,7 @@ orgs:
     - maximilien
     - mayaspivak
     - mcdan
+    - mchmarny
     - mdemirhan
     - mfine30
     - mgencur


### PR DESCRIPTION
/assign @thisisnotapril

(For Mark; Simon's assignment was already done in the `knative/peribolos.yaml` file for ACLs, but not at the top-level charter doc.)
