### PR TITLE
Fixed links to samples and contribution guidelines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ tools, platforms, languages, and products. By submitting a tutorial you can
 share your experience and help others who are solving similar problems.
 
 Community tutorials are stored in Markdown files under the `community` folder
-[Community Samples](https://github.com/knative/docs/tree/main/community/samples/README.md).
+[Community Samples](https://github.com/knative/docs/blob/main/code-samples/community/README.md).
 These documents are contributed, reviewed, and maintained by the community.
 
 Submit a Pull Request to the community sample directory under the Knative
 component folder that aligns with your document. For example, Knative Serving
 samples are under the `serving` folder. A reviewer will be assigned to review
 your submission. They'll work with you to ensure that your submission is clear,
-correct, and meets the [style guide](./docs/DOCS-CONTRIBUTING.md), but it helps
+correct, and meets the [style guide](./CONTRIBUTING.md), but it helps
 if you follow it as you write your tutorial.
 
 ## Meetings and work groups

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Submit a Pull Request to the community sample directory under the Knative
 component folder that aligns with your document. For example, Knative Serving
 samples are under the `serving` folder. A reviewer will be assigned to review
 your submission. They'll work with you to ensure that your submission is clear,
-correct, and meets the [style guide](./CONTRIBUTING.md), but it helps
-if you follow it as you write your tutorial.
+correct, and meets the [style guide](https://github.com/knative/docs/blob/main/contribute-to-docs/README.md),
+but it helps if you follow it as you write your tutorial.
 
 ## Meetings and work groups
 


### PR DESCRIPTION
Signed-off-by: Daniel Krook <krook@us.ibm.com>

# Changes

- Fixed link to the moved samples folder
- Fixed link to contribution guidelines

/kind documentation

No issue opened as the pull request only includes two link fixes.