### PR TITLE
chore: remove func from knative org in peribolos

### DIFF
--- a/peribolos/knative-sandbox-OWNERS_ALIASES
+++ b/peribolos/knative-sandbox-OWNERS_ALIASES
@@ -114,9 +114,18 @@ aliases:
   - lkingland
   - matejvasek
   - nainaz
-  - omerbensaadon
   - salaboy
   - zroubalik
+  func-writers:
+  - lance
+  - lkingland
+  - matejvasek
+  - nainaz
+  - salaboy
+  - zroubalik
+  functions-wg-leads:
+  - lance
+  - salaboy
   homebrew-kn-plugins-approvers:
   - dsimansk
   - maximilien
@@ -138,7 +147,6 @@ aliases:
   - lkingland
   - matejvasek
   - nainaz
-  - omerbensaadon
   - salaboy
   - zroubalik
   kn-plugin-migration-approvers:

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -580,12 +580,10 @@ orgs:
         description: Grants write access to client-related repositories.
         privacy: closed
         repos:
-          func-tastic: write
           homebrew-kn-plugins: write
           kn-plugin-admin: write
           kn-plugin-diag: write
           kn-plugin-event: write
-          kn-plugin-func: write
           kn-plugin-migration: write
           kn-plugin-operator: write
           kn-plugin-quickstart: write
@@ -660,6 +658,23 @@ orgs:
             members:
             - lionelvillard
             - travis-minke-sap
+      Func Writers:
+        description: Grants write access to function related repositories
+        privacy: closed
+        repos:
+          func-tastic: write
+          kn-plugin-func: write
+        teams:
+          Functions WG Leads:
+            description: The Working Group leads for Functions
+            members:
+            - lance
+            - salaboy
+        members:
+        - lkingland
+        - matejvasek
+        - zroubalik
+        - nainaz
       Knative Admin:
         description: Individuals in the project who are responsible for billing and
           general project administration.
@@ -1037,7 +1052,6 @@ orgs:
         - lkingland
         - matejvasek
         - zroubalik
-        - omerbensaadon
         - nainaz
         - salaboy
 
@@ -1091,7 +1105,6 @@ orgs:
         - lkingland
         - matejvasek
         - zroubalik
-        - omerbensaadon
         - nainaz
         - salaboy
 

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -666,6 +666,7 @@ orgs:
           kn-plugin-func: write
         teams:
           Functions WG Leads:
+            privacy: closed
             description: The Working Group leads for Functions
             members:
             - lance


### PR DESCRIPTION
We have not found bandwidth to move the repo yet, and the fact that the
teams/groups are out of sync with reality needs to be addressed in the
meantime. This commit shifts ownership from the client to the functions
working group in knative-sandbox and introduces working group leads for
the two function repositories (kn-plugin-func and func-tastic). And incidentally
removes Omer from the committers list.

Signed-off-by: Lance Ball <lball@redhat.com>
