### PR TITLE
Add new GKE RBAC group for a new cluster

### DIFF
--- a/groups/groups_test.go
+++ b/groups/groups_test.go
@@ -209,7 +209,7 @@ func TestK8sInfraRBACGroupConventions(t *testing.T) {
 	}
 	foundGKEGroup := false
 	for _, g := range cfg.Groups {
-		if g.EmailId == "gke-security-groups@knative.team" {
+		if g.EmailId == "gke-security-groups@knative.dev" {
 			foundGKEGroup = true
 			// this is necessary for group-based rbac to work
 			whoCanViewMembership, ok := g.Settings["WhoCanViewMembership"]
@@ -218,7 +218,7 @@ func TestK8sInfraRBACGroupConventions(t *testing.T) {
 			}
 			for _, email := range g.Members {
 				if _, ok := rbacEmails[email]; !ok {
-					t.Errorf("group '%s': invalid member '%s', must be a k8s-infra-rbac-*@knative.team group", g.Name, email)
+					t.Errorf("group '%s': invalid member '%s', must be a k8s-infra-rbac-*@knative.dev group", g.Name, email)
 				} else {
 					rbacEmails[email] = true
 				}
@@ -226,11 +226,11 @@ func TestK8sInfraRBACGroupConventions(t *testing.T) {
 		}
 	}
 	if !foundGKEGroup {
-		t.Errorf("group '%s' is missing", "gke-security-groups@knative.team")
+		t.Errorf("group '%s' is missing", "gke-security-groups@knative.dev")
 	}
 	for email, found := range rbacEmails {
 		if !found {
-			t.Errorf("group '%s': must be a member of gke-security-groups@knative.team", email)
+			t.Errorf("group '%s': must be a member of gke-security-groups@knative.dev", email)
 		}
 	}
 }
@@ -276,7 +276,7 @@ func TestNoDuplicateMembers(t *testing.T) {
 // // of these groups, we don't want to accidentally lock ourselves out
 func TestHardcodedGroupsForParanoia(t *testing.T) {
 	groups := map[string][]string{
-		"kn-infra-gcp-org-admins@knative.team": {
+		"kn-infra-gcp-org-admins@knative.dev": {
 			"chizhg@google.com",
 			"cy@borg.dev",
 			"chizhg@knative.team",

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -14,9 +14,9 @@ restrictions:
       - "^elections@knative.team$"
   - path: "wg-productivity/groups.yaml"
     allowedGroups:
-      - "^gke-security-groups@knative.team$"
-      - "^kn-infra-gcp-org-admins@knative.team$"
-      - "^k8s-infra-rbac-[a-z]{0,8}@knative.team$"
+      - "^gke-security-groups@knative.dev$"
+      - "^kn-infra-gcp-org-admins@knative.dev$"
+      - "^k8s-infra-rbac-[a-z,-]{0,30}@knative.dev$"
       - "^automation@knative.team$"
   - path: "wg-security/groups.yaml"
     allowedGroups:

--- a/groups/wg-productivity/groups.yaml
+++ b/groups/wg-productivity/groups.yaml
@@ -11,13 +11,11 @@ groups:
   ### GROUPS FOR GKE/GCP RBAC
   ###
 
-  - email-id: kn-infra-gcp-org-admins@knative.team
+  - email-id: kn-infra-gcp-org-admins@knative.dev
     name: kn-infra-gcp-org-admins
     description: |-
-      grants owner access to the knative.team GCP organization, as well as
+      grants owner access to the knative.dev GCP organization, as well as
       additional privileges necessary for billing and admin purposes
-
-      access granted via custom organization role organization.admin
     settings:
       ReconcileMembers: "true"
     members:
@@ -32,7 +30,7 @@ groups:
       - hh@cncf.io
 
   # Every GKE RBAC group should be added here.
-  - email-id: gke-security-groups@knative.team
+  - email-id: gke-security-groups@knative.dev
     name: gke-security-groups
     description: |-
       Security Groups for GKE clusters
@@ -40,14 +38,15 @@ groups:
       ReconcileMembers: "true"
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # needed for RBAC
     members:
-      - k8s-infra-rbac-prow@knative.team
+      - k8s-infra-rbac-prow@knative.dev
+      - k8s-infra-rbac-perf-tests@knative.dev
 
   # GKE RBAC groups:
-  # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster
+  # - grant access to the `namespace-user` role for a single namespace on a cluster
   # - must have WhoCanViewMemberShip: "ALL_MEMBERS_CAN_VIEW"
-  # - must be members of gke-security-groups@kubernetes.io
+  # - must be members of gke-security-groups@knative.dev
 
-  - email-id: k8s-infra-rbac-prow@knative.team
+  - email-id: k8s-infra-rbac-prow@knative.dev
     name: k8s-infra-rbac-prow
     description: |-
       Grants access to the prow cluster
@@ -57,6 +56,16 @@ groups:
     members:
       - chizhg@google.com
       - kmahapatra@vmware.com
+
+  - email-id: k8s-infra-rbac-perf-tests@knative.dev
+    name: k8s-infra-rbac-perf-tests
+    description: |-
+      Grants access to the shared community cluster perf-tests namespace
+    settings:
+      ReconcileMembers: "true"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
+    members:
+      - nziada@vmware.com
 
   ###
   ### Productivity WG related mailing lists


### PR DESCRIPTION
Part of https://github.com/knative/test-infra/pull/3409

We recently added knative.dev and I want to use this domain for GCP RBAC groups that never needed emails before. Looks better than .team domain.

I also added Nader's email so he can get access to the clusters.

/hold I will need to rename groups in the console before merging as I don't want new groups being made. FYI, when a google group email is changed, the IAM bindings will still be there but the new address will be shown in the IAM policy.

/cc @kvmware 