### PR TITLE
process-change: loosen requirements for approvers

### DIFF
--- a/ROLES.md
+++ b/ROLES.md
@@ -188,16 +188,9 @@ approver in an OWNERS file:
 
 - Reviewer of the codebase for at least 3 months.
 
-- Primary reviewer for at least 10 substantial PRs to the codebase.
+- Should have reviewed or contributed to substantial PRs to the codebase.
 
-  - One path for getting the necessary reviews is to add yourself to the
-    `reviewers` section of the OWNERS file. Note that this does not give you any
-    additional privileges. By having yourself listed in this section in OWNERS
-    file means that you will get PRs assigned to you for code review. Getting
-    added to `reviewers` section is at the discretion of an approver after
-    enough evidence of quality contributions.
-
-- Reviewed at least 30 PRs to the codebase.
+- Should be a `reviewer` in the OWNERS file.
 
 - Nominated by an a WG lead (with no objections from other leads).
 


### PR DESCRIPTION
The approver role can be difficult to assign for repositories with lower
velocity or for those with a small number of (e.g. 2) primary
contributors, where the contributor seeking the approval role is making
most of the code contributions. This change attempts to address that
situation by removing a hard number requirement, and allowing for
individual contributions to be considered as well. Finally, instead of
simply suggesting that the contributor be in the OWNERS file, this
change strengthens that as a requirement.

Signed-off-by: Lance Ball <lball@redhat.com>
