### PR TITLE
added astelmashenko as Knative Sandbox member

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -984,7 +984,6 @@ orgs:
         repos:
           eventing-natss: write
         members:
-        - astelmashenko
         - zhaojizhuang
 
       eventing-prometheus Approvers:

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -47,6 +47,7 @@ orgs:
     - arturenault
     - aslakknutsen
     - aslom
+    - astelmashenko
     - balopat
     - bbrowning
     - bbtong
@@ -983,6 +984,7 @@ orgs:
         repos:
           eventing-natss: write
         members:
+        - astelmashenko
         - zhaojizhuang
 
       eventing-prometheus Approvers:

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -64,6 +64,7 @@ orgs:
     - asciimike
     - aslakknutsen
     - aslom
+    - astelmashenko
     - asyoussef
     - atmandhol
     - averikitsch


### PR DESCRIPTION
added myself as sandbox member:
- I'm active in [user group](https://groups.google.com/g/knative-users/)  (Andrey Stelmashenko, astelmashenko@viax.io, using corporate account there)
- requested subscription in [dev group](https://groups.google.com/g/knative-dev?pli=1)
- made a PR regarding [tracing propagation](https://github.com/knative-sandbox/eventing-natss/pull/342) and going to do more, because k8s native technologies are interesting to me (I promoted knative in a company where I work)
