### PR TITLE
Added member haubenr

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -119,6 +119,7 @@ orgs:
     - gyohuangxin
     - halvards
     - Haolicopter
+    - haubenr
     - hev
     - houshengbo
     - hh

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -215,6 +215,7 @@ orgs:
     - Haolicopter
     - hardl
     - hatofmonkeys
+    - haubenr
     - Henrike42
     - hev
     - hh


### PR DESCRIPTION
Signed-off-by: Dirk Haubenreisser <haubenr@de.ibm.com>

# Changes
This PR adds the GH user ID 'haubenr' to the knative and knative-sandbox projects member list.
'haubenr' (myself) is the current knative maintainer for the IBM zSystems (aka s390x) platform.