### PR TITLE
Add chzhyang to kperf approvers

### DIFF
--- a/peribolos/knative-sandbox-OWNERS_ALIASES
+++ b/peribolos/knative-sandbox-OWNERS_ALIASES
@@ -201,11 +201,11 @@ aliases:
   - knative-prow-updater-robot
   - knative-test-reporter-robot
   kperf-approvers:
+  - chzhyang
   - maximilien
   - nader-ziada
   - psschwei
   - zhanggbj
-  - chzhyang
   net-certmanager-approvers:
   - ZhiminXiang
   - carlisia

--- a/peribolos/knative-sandbox-OWNERS_ALIASES
+++ b/peribolos/knative-sandbox-OWNERS_ALIASES
@@ -205,6 +205,7 @@ aliases:
   - nader-ziada
   - psschwei
   - zhanggbj
+  - chzhyang
   net-certmanager-approvers:
   - ZhiminXiang
   - carlisia

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -1177,6 +1177,7 @@ orgs:
         - zhanggbj
         - psschwei
         - nader-ziada
+        - chzhyang
 
       net-contour Approvers:
         description: Approver group for net-contour - to be used in CODEOWNERS file


### PR DESCRIPTION
# Changes
- Adding chzhyang as an approver for the knative-sandbox/kperf repo

My contributions to Kperf could be found here: https://github.com/knative-sandbox/kperf/pulls?q=is%3Apr+is%3Aclosed+author%3Achzhyang, including:
  - Added the load command to kperf
  - Added config file support to kperf
  - Bug fixes
  - PRs review

I will continue to enhance kperf in the future.

/cc @maximilien @psschwei 