### PR TITLE
Add EasyCLA step to new repo checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-repo.md
+++ b/.github/ISSUE_TEMPLATE/new-repo.md
@@ -36,6 +36,8 @@ _You may not be able to use the Projects quick menu on this page. In that case, 
 
 **TOC Gate**: _Once the TOC has approved the above, it will merge and Peribolos will create an empty repository._
 
+- [ ] Ask Steering to add the repo to EasyCLA in [Slack](https://knative.slack.com/archives/CU9DGL4FM).
+
 - [ ] (golang) Send a PR to add aliases for `knative.dev/$REPONAME` import paths ([sample](https://github.com/knative/docs/pull/4160)).
 
 - [ ] Have a lead from the sponsoring WG bootstrap the Git repository by pushing an


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

From [discussion in slack](https://knative.slack.com/archives/CCSNR4FCH/p1659977234489749), turns out we need to request that each new repo get added to EasyCLA. This PR adds that step to the new repo checklist.

/assign @lance 