### PR TITLE
Add psschwei as serving WG lead

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -179,6 +179,7 @@ aliases:
   - whaught
   serving-wg-leads:
   - dprotaso
+  - psschwei
   serving-writers:
   - dprotaso
   - julz

--- a/peribolos/knative-sandbox-OWNERS_ALIASES
+++ b/peribolos/knative-sandbox-OWNERS_ALIASES
@@ -270,6 +270,7 @@ aliases:
   - julz
   serving-wg-leads:
   - dprotaso
+  - psschwei
   serving-writers:
   - dprotaso
   - nak3

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -831,6 +831,7 @@ orgs:
             description: The Working Group leads for Serving
             members:
             - dprotaso
+            - psschwei
             privacy: closed
           Networking WG Leads:
             description: The Working Group leads for Networking

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -1071,6 +1071,7 @@ orgs:
             description: The Working Group leads for Serving
             members:
             - dprotaso
+            - psschwei
             privacy: closed
       UX Writers:
         description: Grants write access to ux related repositories.

--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -93,6 +93,7 @@ Covers API [resources](https://github.com/knative/serving/tree/main/pkg/apis/ser
 | &nbsp;                                                   | Leads            | Company | Profile                                 |
 | -------------------------------------------------------- | ---------------- | ------- | --------------------------------------- |
 | <img width="30px" src="https://github.com/dprotaso.png"> | Dave Protasowski | VMware  | [dprotaso](https://github.com/dprotaso) |
+| <img width="30px" src="https://github.com/psschwei.png"> | Paul Schweigert | IBM  | [psschwei](https://github.com/psschwei) |
 
 | &nbsp;                                                         | Emeritus Leads  | Subgroup | Profile                                             | Duration  |
 | -------------------------------------------------------------- | --------------- | -------- | --------------------------------------------------- | --------- |


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

# Changes

Adding myself as a working group lead for serving.

Evidence of having met requirements:

### Recognized as having expertise in the group’s subject matter.

Noted as on track for lead in the [July 28 WG update](https://docs.google.com/presentation/d/1IUa4Jn4d-PkdFbHLBt_aZ5EOrxMTSVQx3j6FNgf8ay4/edit#slide=id.g3fc1c3445b_0_31) by @dprotaso (current WG lead)

### Approver for a relevant part of the codebase for at least 3 months.

Approver since [May 11, 2022](https://github.com/knative/community/pull/1045)

### Member for at least 6 months.

Member since [May 14, 2021](https://github.com/knative/community/pull/606)

### Should have reviewed or contributed to substantial PRs to the codebase.

Serving PRs: https://github.com/knative/serving/pulls?q=is%3Apr+author%3Apsschwei+

Serving Reviews: https://github.com/knative/serving/pulls?q=is%3Apr+reviewed-by%3Apsschwei+

### Should be a reviewer in the OWNERS file.

Am a [reviewer](https://github.com/knative/serving/blob/5bba016c00941c1266b9e7bd50f3c5f90154417b/OWNERS_ALIASES#L177)

### Sponsored by the technical oversight committee.

@knative/technical-oversight-committee 
