### PR TITLE
Add cli leads to quickstart approvers

### DIFF
--- a/peribolos/knative-sandbox-OWNERS_ALIASES
+++ b/peribolos/knative-sandbox-OWNERS_ALIASES
@@ -159,9 +159,10 @@ aliases:
   - omerbensaadon
   - rhuss
   kn-plugin-quickstart-approvers:
-  - csantanapr
-  - omerbensaadon
+  - dsimansk
+  - navidshaikh
   - psschwei
+  - rhuss
   kn-plugin-sample-approvers:
   - maximilien
   - navidshaikh

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -1147,8 +1147,9 @@ orgs:
         repos:
           kn-plugin-quickstart: write
         members:
-        - csantanapr
-        - omerbensaadon
+        - dsimansk
+        - navidshaikh
+        - rhuss
         - psschwei
 
       kn-plugin-sample Approvers:


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

# Changes

Like the other kn plugins, bringing quickstart over to the client WG

xref: https://github.com/knative-sandbox/knobots/pull/233

/assign @dsimansk 
FYI @rhuss @navidshaikh 

