### PR TITLE
Update release schedule to quarterly!

### DIFF
--- a/mechanics/RELEASE-SCHEDULE.md
+++ b/mechanics/RELEASE-SCHEDULE.md
@@ -5,15 +5,27 @@ weight: 50
 type: "docs"
 ---
 
-Knative releases every 6 weeks. As much as possible, releases should be driven by automation, and repos should be ready to release at any point. It should also be possible to produce and consume nightly artifacts.
+Knative currently releases quarterly, on the 4th Tuesday of January, April, July, and October. See [this document](https://docs.google.com/document/d/12yboQGExbbow5yYbIjNlZegOvw5X9ohYCaRT4kepP4s/edit#) for the rationale behind the current schedule. Previously, Knative released on a 6-weekly schedule.
 
-With that said, it can be useful to have a list of when future releases will happen, so this document provides a schedule for the next 6+ months of releases.
+The current release schedule can be expressed with the following crontab expression:
+
+```
+# minute   hour   day      month        weekday
+0          0      22-28    1,4,7,10     2
+```
+
+The date range 22-28 restricts the days to the 4th week of the month; the weekday specification restricts further the day to be the day of the week which is a Tuesday within that 4th week of the month. As much as possible, releases should be driven by automation, and repos should be ready to release at any point. It should also be possible to produce and consume nightly artifacts.
+
+As a transition point, and due to Kubecon occurring on 24 Oct 2022, the first quarterly release has been moved a week earlier. We expect that subsequent conferences / etc will not have a similar release date change. (See [#1096](https://github.com/knative/community/issues/1096).)
+
+Here is the current release schedule for the next year:
 
 | Release | Date       | EOL        | Min K8s Version | Notes                         |
 | ------- | ---------- | ---------- | --------------- | ----------------------------- |
-| 1.8     | 2022-10-04 | 2023-04-04 | 1.23            | |
-| 1.9     | 2022-11-15 | 2023-05-16 | 1.23            | |
-| 1.10    | 2023-01-10 | 2023-06-27 | 1.24            | |
+| 1.8     | 2022-10-18 | 2023-04-25 | 1.23            | |
+| 1.9     | 2023-01-24 | 2023-07-25 | 1.24            | |
+| 1.10    | 2023-04-25 | 2023-10-24 | <unknown>       | |
+| 1.11    | 2023-07-25 | 2024-01-23 | <unknown>       | |
 
 
 ## Historical (no longer supported) releases:

--- a/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
+++ b/mechanics/RELEASE-VERSIONING-PRINCIPLES.md
@@ -46,7 +46,7 @@ Upstream reference: https://kubernetes.io/releases/patch-releases
 
 ### Knative community support window principle:
 
-We (the community) support the most recent 4 versions of Knative. The term
+We (the community) support Knative release versions for 6 months. The term
 support as used here means that we will maintain release branches for these
 releases. We will consider backporting applicable fixes to these release
 branches depending on severity and feasibility.


### PR DESCRIPTION
# Changes

- Update release schedule with changes from [Release Cadence proposal document](https://docs.google.com/document/d/12yboQGExbbow5yYbIjNlZegOvw5X9ohYCaRT4kepP4s/edit#), particularly the quarterly variant.
- Adjust our support window to be 6 months, rather than N versions
- Vary the crontab-based schedule by a week for Oct 2022 release in deference to Kubecon presentations.

<!--
/kind api-change

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1096 

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Starting with release 1.8, Knative will release on a quarterly schedule.
```
