### PR TITLE
Update MATURITY-LEVELS.md to have concrete coverage level

### DIFF
--- a/mechanics/MATURITY-LEVELS.md
+++ b/mechanics/MATURITY-LEVELS.md
@@ -63,7 +63,7 @@ Additional requirements beyond "initiating":
     the release artifacts. Commercial products with production usage count
     towards this target. This can be documented in something
     [like an ADOPTERS.md file](https://www.google.com/url?q=https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc&sa=D&ust=1597952611892000&usg=AFQjCNFymwghRnNGVqbD0O_01TsfEeto5w).
-- Unit test automation meeting the Knative standards with respect to coverage
+- Unit test automation meeting the Knative standards with respect to coverage for usable components (50% + using [codecov](https://app.codecov.io/gh/knative/serving))
   and flakiness / test failures.
 - Provide at least monthly progress reports at the appropriate WG(s). WGs should
   roll these reports up into their TOC reports.
@@ -93,6 +93,7 @@ Additional requirements beyond "usable":
   The API contract should be explicitly documented in the repo.
 - Identified and named set of project leads managing both development roadmap
   and overall project success.
+- Unit test automation meeting the Knative standards with respect to coverage for usable components (70% + using [codecov](https://app.codecov.io/gh/knative/serving))
 - Release schedule aligned with the core Knative release schedule.
 - At least 5 end-users consuming the release artifacts in installations of
   sufficient quality and scope.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

This is a proposal to add the coverage level for Usable and Stable components. Even if the levels are not ok, we should be explicit about how much coverage is required for both levels of maturity. 

- :gift: add link to codecov example and add 50% coverage level for Usable components.
- :gift: add link to codecov example and add 70% coverage level for Stable components.


/kind enhancement


<!-- Please include the 'why' behind your changes if no issue exists -->

It doesn't fix an issue because this is an update on the maturity levels that needs to be discussed with Steering. I couldn't find any other doc where these coverage levels are mentioned, as they are only configured in codecov. 

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
