### PR TITLE
chore: add entries for knative/func

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -53,6 +53,18 @@ aliases:
   - matzew
   - odacremolbap
   - pierDipi
+  func-reviewers:
+  - jrangelramos
+  - nainaz
+  func-writers:
+  - lance
+  - lkingland
+  - matejvasek
+  - salaboy
+  - zroubalik
+  functions-wg-leads:
+  - lance
+  - salaboy
   knative-admin:
   - csantanapr
   - dprotaso

--- a/peribolos/knative-sandbox-OWNERS_ALIASES
+++ b/peribolos/knative-sandbox-OWNERS_ALIASES
@@ -114,16 +114,13 @@ aliases:
   - nainaz
   - salaboy
   - zroubalik
-  func-writers:
+  functastic-writers:
   - lance
   - lkingland
   - matejvasek
   - nainaz
   - salaboy
   - zroubalik
-  functions-wg-leads:
-  - lance
-  - salaboy
   homebrew-kn-plugins-approvers:
   - dsimansk
   - maximilien
@@ -140,14 +137,6 @@ aliases:
   kn-plugin-event-approvers:
   - cardil
   - rhuss
-  kn-plugin-func-approvers:
-  - jrangelramos
-  - lance
-  - lkingland
-  - matejvasek
-  - nainaz
-  - salaboy
-  - zroubalik
   kn-plugin-migration-approvers:
   - maximilien
   - zhangtbj

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -443,12 +443,6 @@ orgs:
         description: Kn plugin for sending events to Knative sinks.
         has_projects: true
         has_wiki: false
-      kn-plugin-func:
-        allow_merge_commit: false
-        allow_rebase_merge: false
-        description: Kn plugin for functions.
-        has_projects: true
-        has_wiki: false
       kn-plugin-migration:
         allow_merge_commit: false
         allow_rebase_merge: false
@@ -665,24 +659,18 @@ orgs:
             members:
             - lionelvillard
             - travis-minke-sap
-      Func Writers:
+      Functastic Writers:
         description: Grants write access to function related repositories
         privacy: closed
         repos:
           func-tastic: write
-          kn-plugin-func: write
-        teams:
-          Functions WG Leads:
-            privacy: closed
-            description: The Working Group leads for Functions
-            members:
-            - lance
-            - salaboy
         members:
+        - lance
         - lkingland
         - matejvasek
-        - zroubalik
         - nainaz
+        - salaboy
+        - zroubalik
       Knative Admin:
         description: Individuals in the project who are responsible for billing and
           general project administration.
@@ -714,7 +702,6 @@ orgs:
           kn-plugin-admin: admin
           kn-plugin-diag: admin
           kn-plugin-event: admin
-          kn-plugin-func: admin
           kn-plugin-migration: admin
           kn-plugin-operator: admin
           kn-plugin-quickstart: admin
@@ -1104,20 +1091,6 @@ orgs:
         members:
         - cardil
         - rhuss
-
-      kn-plugin-func Approvers:
-        description: Approver group for kn-plugin-func
-        privacy: closed
-        repos:
-          kn-plugin-func: write
-        members:
-        - lance
-        - lkingland
-        - matejvasek
-        - zroubalik
-        - nainaz
-        - salaboy
-        - jrangelramos
 
       kn-plugin-migration Approvers:
         description: Approver group for kn-plugin-migration - to be used in CODEOWNERS file

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -635,6 +635,12 @@ orgs:
         description: 'DEPRECATED: Development continues in https://github.com/knative/operator/'
         has_projects: true
         has_wiki: false
+      func:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        description: 'Knative Functions client API and CLI'
+        has_projects: true
+        has_wiki: false
       infra:
         allow_merge_commit: false
         allow_rebase_merge: false
@@ -816,6 +822,29 @@ orgs:
         - aliok
         - matzew
         - odacremolbap
+      Func Writers:
+        description: Grants write access to function repositories
+        privacy: closed
+        repos:
+          func: write
+          release: write
+        teams:
+          Functions WG Leads:
+            description: The Working Group leads for Functions
+            members:
+              - lance
+              - salaboy
+              privacy: closed
+        members:
+          - lkingland
+          - matejvasek
+          - zroubalik
+      Func Reviewers:
+        description: Receive reviews for function repositories
+        privacy: closed
+        members:
+          - jrangelramos
+          - nainaz
       Knative Admin:
         description: Individuals in the project who are responsible for billing and
           general project administration.
@@ -834,6 +863,7 @@ orgs:
           eventing: admin
           eventing-contrib: admin
           eventing-operator: admin
+          func: admin
           infra: admin
           homebrew-client: admin
           networking: admin

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -832,9 +832,9 @@ orgs:
           Functions WG Leads:
             description: The Working Group leads for Functions
             members:
-              - lance
-              - salaboy
-              privacy: closed
+            - lance
+            - salaboy
+            privacy: closed
         members:
           - lkingland
           - matejvasek
@@ -843,8 +843,8 @@ orgs:
         description: Receive reviews for function repositories
         privacy: closed
         members:
-          - jrangelramos
-          - nainaz
+        - jrangelramos
+        - nainaz
       Knative Admin:
         description: Individuals in the project who are responsible for billing and
           general project administration.


### PR DESCRIPTION
This commit moves knative-sandbox/kn-plugin-func and the team members over to knative/func.

See: https://github.com/knative/community/issues/1169

Signed-off-by: Lance Ball <lball@redhat.com>
