### PR TITLE
Changed deadline for new SC members to take office

### DIFF
--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -164,8 +164,8 @@ call for nominations, publish the list of voters, and open the call for
 exceptions. One week before the election the call for nominations and exceptions
 will be closed. The election will be open for voting not less than two weeks and
 not more than four. The results of the election will be announced within one
-week of closing the election. New Steering Committee members will take office on
-December 1 of each year.
+week of closing the election. New Steering Committee members will take office in
+December of each year on the date the results are announced.
 
 ### Election Officer(s)
 


### PR DESCRIPTION
Removed the hard deadline of Dec 1 for new SC members to take office, since that will always be difficult due to the US Thanksgiving holiday timing. Changed it to be less specific, but still in December, and tied to the date of the election announcement to give us a little more flexibility.

This change requires approval from @knative/steering-committee 
cc: @jberkus 

/hold
