### PR TITLE
Allow `elections@knative.team` to receive emails from the world

### DIFF
--- a/groups/committee-steering/groups.yaml
+++ b/groups/committee-steering/groups.yaml
@@ -22,6 +22,7 @@ groups:
       Knative Elections Mailing List
     settings:
       ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
     members:
       - fosterd@vmware.com
       - jberkus@redhat.com


### PR DESCRIPTION
Applying https://github.com/knative/community/pull/1166 to elections group as well

/cc @lance 