### PR TITLE
Removes inactive member to fix func owners issue

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -157,7 +157,6 @@ aliases:
   productivity-reviewers:
   - albertomilan
   - evankanderson
-  - gerardo-lc
   - mgencur
   - shinigambit
   productivity-wg-leads:

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -105,7 +105,6 @@ orgs:
     - gabo1208
     - garron
     - georgeharley
-    - gerardo-lc
     - glaforge
     - glyn
     - gorkem

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -194,7 +194,6 @@ orgs:
     - garron
     - geekygirldawn
     - georgeharley
-    - gerardo-lc
     - Gerg
     - glaforge
     - glickbot
@@ -1040,7 +1039,6 @@ orgs:
         members:
         - albertomilan
         - evankanderson
-        - gerardo-lc
         - shinigambit
         - mgencur
       Productivity Writers:


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

# Changes

As discussed in [Slack](https://knative.slack.com/archives/CCSNR4FCH/p1666360097149169), there's an inactive member who never accepted the invite to the org, which is causing problems with the owners files in the func repo. As the person has had no github activity in over a year (and also no knative activity), this PR drops that person from the org list.

cc @lance @upodroid 