### PR TITLE
Updating peribolos with TM committee changes

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -79,11 +79,11 @@ aliases:
   - kvmware
   - lance
   - lionelvillard
+  - mchmarny
   - nak3
   - pmorie
   - psschwei
   - smoser-ibm
-  - spencerdillard
   - thisisnotapril
   - upodroid
   - vaikas
@@ -212,8 +212,8 @@ aliases:
   - zroubalik
   trademark-committee:
   - evankanderson
+  - mchmarny
   - smoser-ibm
-  - spencerdillard
   ux-wg-leads:
   - abrennan89
   - snneji

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -448,7 +448,6 @@ orgs:
     - smarterclayton
     - smoser-ibm
     - snneji
-    - spencerdillard
     - squee1945
     - sreetummidi
     - srinivashegde86
@@ -925,7 +924,7 @@ orgs:
             maintainers:
             - evankanderson
             - smoser-ibm
-            - spencerdillard
+            - mchmarny
             privacy: closed
           Technical Oversight Committee:
             description: Members of the Knative Technical Oversight Committee (TOC)


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Mark was added to TM in PR #1105, this adds that change to peribolos.

This also fixes a blocker for functions: https://github.com/knative/func/pull/1342#issuecomment-1296432869 

cc @mchmarny 

