### PR TITLE
Updates to security / eventing sources emeritus tables

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -167,10 +167,8 @@ aliases:
   - upodroid
   security-wg-leads:
   - evankanderson
-  - julz
   security-writers:
   - evankanderson
-  - julz
   serving-observability-reviewers:
   - skonto
   - yanweiguo

--- a/peribolos/knative-sandbox-OWNERS_ALIASES
+++ b/peribolos/knative-sandbox-OWNERS_ALIASES
@@ -256,10 +256,8 @@ aliases:
   - rhuss
   security-wg-leads:
   - evankanderson
-  - julz
   security-writers:
   - evankanderson
-  - julz
   serving-wg-leads:
   - dprotaso
   - psschwei

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -897,7 +897,6 @@ orgs:
             description: The Working Group leads for Security
             members:
             - evankanderson
-            - julz
       Serving Writers:
         description: Grants write access to serving-related repositories.
         privacy: closed

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -1070,7 +1070,6 @@ orgs:
             description: The Working Group leads for Security
             members:
             - evankanderson
-            - julz
         repos:
           release: write
       Serving Observability Reviewers:

--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -343,7 +343,10 @@ Security concerns across Knative components
 | &nbsp;                                                        | Leads           | Company | Profile                                           |
 | ------------------------------------------------------------- | --------------- | ------- | ------------------------------------------------- |
 | <img width="30px" src="https://github.com/evankanderson.png"> | Evan Anderson   | VMware  | [evankanderson](https://github.com/evankanderson) |
-| <img width="30px" src="https://github.com/julz.png">          | Julian Friedman | IBM     | [julz](https://github.com/julz)                   |
+
+| &nbsp;                                                     | Emeritus Leads | Profile                                     | Duration  |
+| ---------------------------------------------------------- | -------------- | ------------------------------------------- | --------- |
+| <img width="30px" src="https://github.com/julz.png">          | Julian Friedman |[julz](https://github.com/julz)                   | 2021-2022 |
 
 ---
 
@@ -375,7 +378,7 @@ The Eventing Sources working group was responsible for various event producers, 
 
 | &nbsp;                                                    | Emeritus Leads       | Profile                                   | Duration  |
 | --------------------------------------------------------- | -------------------- | ----------------------------------------- | --------- |
-| <img width="30px" src="https://github.com/lionelvillard.png"> | Lionel Villard | IBM     | [lionelvillard](https://github.com/lionelvillard) |
+| <img width="30px" src="https://github.com/lionelvillard.png"> | Lionel Villard | [lionelvillard](https://github.com/lionelvillard) | 2019-2022 |
 | <img width="30px" src="https://github.com/nachocano.png"> | Ignacio (Nacho) Cano | [nachocano](https://github.com/nachocano) | 2019-2020 |
 | <img width="30px" src="https://github.com/vaikas.png">    | Ville Aikas          | [vaikas](https://github.com/vaikas)       | 2019-2021 |
 | <img width="30px" src="https://github.com/n3wscott.png">  | Scott Nichols        | [n3wscott](https://github.com/n3wscott)   | 2019-2021 |


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

# Changes

Makes a couple of updates to the emeritus sections of a couple of working groups:

* moves @julz to emeritus section for security (also removes him from peribolos)
* adds the dates for @lionelvillard 's time as lead of eventing sources

/assign @evankanderson 