### PR TITLE
Fixing smoser-ibm candidate profile format

### DIFF
--- a/elections/2022-SC/candidate-smoser-ibm.md
+++ b/elections/2022-SC/candidate-smoser-ibm.md
@@ -1,5 +1,5 @@
 -------------------------------------------------------------
-Name: Simon Moser 
+name: Simon Moser 
 ID: smoser-ibm
 info:
   - affiliation: IBM


### PR DESCRIPTION
fix typo in format for Elekto - name field in the yaml file should be lowercase