### PR TITLE
voters.yaml update for AngeloDanducci

### DIFF
--- a/elections/2022-SC/voters.yaml
+++ b/elections/2022-SC/voters.yaml
@@ -48,7 +48,7 @@ eligible_voters:
   - vyasgun
   - travis-minke-sap
   - aslom
-  - angelodanducci
+  - AngeloDanducci
   - haubenr
   - omerbensaadon
   - ricardozanini


### PR DESCRIPTION
changed the case for AngeloDanducci's voters.yaml gh id as a workaround to the Elekto case bug to allow voter eligibility in Elekto

