### PR TITLE
Fixed GH login case for several users in voters.yaml

### DIFF
--- a/elections/2022-SC/voters.yaml
+++ b/elections/2022-SC/voters.yaml
@@ -1,7 +1,7 @@
 # list of eligible voters
 eligible_voters:
   - nainaz
-  - Pmbanugo
+  - pmbanugo
   - pierDipi
   - dprotaso
   - matzew
@@ -42,7 +42,7 @@ eligible_voters:
   - odacremolbap
   - vaikas
   - jwcesign
-  - zhiminxiang
+  - ZhiminXiang
   - gvmw
   - mattmoor
   - vyasgun
@@ -54,7 +54,7 @@ eligible_voters:
   - ricardozanini
   - ikvmw
   - jrangelramos
-  - chunyilyu
+  - ChunyiLyu
   - antoineco
   - daisy-ycguo
   - chzhyang
@@ -62,14 +62,14 @@ eligible_voters:
   - steven0711dong
   - embano1
   - geekygirldawn
-  - bbolroc
+  - BbolroC
   - n3wscott
-  - shashankft9
+  - Shashankft9
   - liuchangyan
   - astelmashenko
   - tzununbekov
   - jberkus
-  - ramychaabane
+  - RamyChaabane
   - zhaojizhuang
   - thisisnotapril
   - itsmurugappan


### PR DESCRIPTION
Fixed the remainder of the eligible voters that didn't match the case of their GH login with the voters.yaml file to get around the bug in Elekto.