### PR TITLE
Add security GSoC projects

### DIFF
--- a/google-summer-of-code/gsoc-2023.md
+++ b/google-summer-of-code/gsoc-2023.md
@@ -8,6 +8,8 @@ However, we collect ideas in our community until Google announces the program an
 
 ## Ideas
 - [Multiple Knative Eventing control planes](#multiple-knative-eventing-control-planes)
+- [Eventing Sender Identity](#eventing-sender-identity)
+- [NetworkPolicy support for Knative Serving](#networkpolicy-support-for-knative-serving)
 
 ### Multiple Knative Eventing control planes
 
@@ -18,3 +20,23 @@ However, we collect ideas in our community until Google announces the program an
 - Recommended Skills: Golang, Kubernetes, Knative, Kubernetes Controllers
 - Mentor(s):  Ali Ok @aliok
 - Upstream Issue (URL): https://github.com/knative/eventing/issues/6601
+
+### Eventing Sender Identity
+
+- Description: Leveraging Kubernetes Service Account identity and OAuth audiences, users should be able to configure Knative Eventing components to authenticate CloudEvent deliveries using the identity of the Subscription, Trigger, or Source. Additionally, Brokers and Channels can leverage the OAuth identity associated with incoming CloudEvents to implement policy.
+- Expected outcome: At least the following components are able to use service accounts for authentication: in-memory-channel, multitenant broker, apiserver source, ping source. Ideally, the primitives from this project could be re-used by other channel and broker implementations.
+- Expected size of the project: 360h
+- Difficulty rating: Medium
+- Recommended Skills: Golang, Kubernetes, OAuth or OIDC
+- Mentor(s): Evan Anderson @evankanderson
+- Upstream Issue (URL): https://github.com/knative/eventing/issues/5047
+
+### NetworkPolicy support for Knative Serving
+
+- Description: Implement port-level network routing for Knative Serving internal addresses. This will be an extension of https://github.com/knative-sandbox/net-kourier/pull/852 to other Knative Ingress implementations, along with implementation of default NetworkPolicies for the activator and Knative Revisions to enforce that requests are routed through the Knative Ingress.
+- Expected outcome: Users will be able to use NetworkPolicy to restrict access to their Knative Services at a network (L4 / TCP) level.
+- Expected size of the project: 320h
+- Difficulty rating: Hard
+- Recommended Skills: Golang, Kubernetes networking, Envoy or protocol familiarity with HTTP
+- Mentor(s): Evan Anderson @evankanderson
+- Upstream Issue (URL): https://github.com/knative/serving/issues/6520


### PR DESCRIPTION
# Changes

- Add some medium-term projects for GSoC from the security WG. Suggested in the Nov 18 TOC meeting as a way to get additional contributors on issues.

/assign @dprotaso