### PR TITLE
drop alexellis due to compromised tokens

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -35,7 +35,6 @@ orgs:
     - akrausesap
     - alanfx
     - albertomilan
-    - alexellis
     - aliok
     - AlyssaDaemon
     - andrew-su

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -45,7 +45,6 @@ orgs:
     - alculquicondor
     - AlexandraRoatis
     - alexdebrie
-    - alexellis
     - aliok
     - AlyssaDaemon
     - amkapoor


### PR DESCRIPTION
Doing this as a precaution

/assign @evankanderson 

Email from GitHub

> Hi dprotaso,
> 
> We’re writing to let you know that we observed suspicious activity that suggests a threat actor accessed your GitHub organization through a compromised organization member or outside collaborator account and downloaded private repository metadata.
> 
> We are in the process of notifying all identified affected users and organizations and revoking associated credentials.
> 
> * What happened *
> 
> We do not believe the attacker obtained these tokens via a compromise of GitHub or its systems, because the tokens in question are not stored by GitHub in their original, usable formats. At this time, evidence suggests that the threat actor(s) used compromised organization member and/or outside collaborator accounts to access the following organizations:
> 
> knative
> 
> The account(s) associated with the compromised token(s) are:
> 
> alexellis
> 
> You can review an example of repository metadata in the example response here:
> 
> https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repositories-for-a-user--code-samples
> 
> * What GitHub is doing *
> 
> GitHub continues to monitor for and investigate signs of suspicious activity. We are in the process of notifying all identified affected users and organizations and revoking associated credentials.
> 
> * What you can do *
> 
> We recommend reviewing your organization’s audit log for suspicious activity:
> 
> https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/reviewing-the-audit-log-for-your-organization
> 
> And that you review your organization’s installed integrations:
> 
> https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-programmatic-access-to-your-organization/reviewing-your-organizations-installed-integrations
> 
> If you haven’t already, we recommend considering enabling OAuth app restrictions for your organization. When OAuth App access restrictions are enabled, organization members and outside collaborators cannot authorize OAuth App access to organization resources:
> 
> https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-oauth-access-to-your-organizations-data/about-oauth-app-access-restrictions#about-oauth-app-access-restrictions
> 
> And you can set a policy for the usage of Personal Access Tokens (PATs) with your organization or Enterprise. Options include restricting access to non-public resources and requiring administrator approval for new tokens:
> 
> https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-programmatic-access-to-your-organization/setting-a-personal-access-token-policy-for-your-organization
> 
> If you’re an owner of an Enterprise organization or an Enterprise owner, you may query the audit log using the Audit Log API for up to six months of history via the REST API:
> 
> https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/using-the-audit-log-api-for-your-enterprise#querying-the-audit-log-rest-api
> 
> Please reach out to us with any additional questions, log requests, or concerns through this contact form:
> 
> https://github.com/contact?form%5Bsubject%5D=Re:Reference+GH-0000345-5460-1c&tags=GH-0000345-5460-1c
> 
> Thanks,
> GitHub Support
> GH-0000345-5460-1c