### PR TITLE
dropping unused repo - kn-plugin-source-pkg

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -552,14 +552,6 @@ orgs:
         has_wiki: false
         squash_merge_commit_title: PR_TITLE
         squash_merge_commit_message: COMMIT_MESSAGES
-      kn-plugin-source-pkg:
-        allow_merge_commit: false
-        allow_rebase_merge: false
-        description: Common code for Kn source plugins
-        has_projects: true
-        has_wiki: false
-        squash_merge_commit_title: PR_TITLE
-        squash_merge_commit_message: COMMIT_MESSAGES
       knobots:
         allow_merge_commit: false
         allow_rebase_merge: false
@@ -689,7 +681,6 @@ orgs:
           kn-plugin-service-log: write
           kn-plugin-source-kafka: write
           kn-plugin-source-kamelet: write
-          kn-plugin-source-pkg: write
         teams:
           Client WG Leads:
             description: The Working Group Leads for Client
@@ -806,7 +797,6 @@ orgs:
           kn-plugin-service-log: admin
           kn-plugin-source-kafka: admin
           kn-plugin-source-kamelet: admin
-          kn-plugin-source-pkg: admin
           knobots: admin
           kperf: admin
           net-certmanager: admin


### PR DESCRIPTION
This repo isn't used and superseded by client-pkg repo

/assign @dsimansk 