### PR TITLE
Re-add rhuss to members of Knative

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -101,6 +101,7 @@ orgs:
     - pmorie
     - quentin-cha
     - ReToCode
+    - rhuss
     - RichieEscarez
     - ricardozanini
     - richterdavid


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

rhuss was accidentally removed in https://github.com/knative/community/commit/daef24b2029c08ec5602d912f9684ed37a4c643a from the knative org, please read.

