### PR TITLE
Add Chainguard/puerco nomination for the EU seat

### DIFF
--- a/elections/2022-SC-EU/candidate-puerco.md
+++ b/elections/2022-SC-EU/candidate-puerco.md
@@ -1,0 +1,27 @@
+-------------------------------------------------------------
+name: Adolfo García Veytia
+ID: puerco
+info:
+  - affiliation: Chainguard
+-------------------------------------------------------------
+
+I would like to nominate myself as a representative of my
+organization for the Knative end user seat. My name is Adolfo García Veytia, a
+software engineer with Chainguard. I usually go by @puerco on all slacks and
+the Internet. While I have done just a few comments on Knative PRs, I am an
+active open source contributor on many projects. I am an active member of the
+Kubernetes community, where I am one of the
+[SIG Release Technical Leads](https://github.com/kubernetes/community/blob/master/sig-release/README.md#technical-leads) and a Release Manager. I have contributed in the past to other cloud native
+projects and Sigstore. I was a recipient of the
+[Chop Wood, Carry Water](https://github.com/cncf/awards#chop-wood-carry-water)
+community awards in 2022. I am also a member of the SPDX community.
+
+Chainguard is an open source first company. Our company employs several
+contributors of Knative and we also depend heavily on the project for our
+products and services. I feel that the open source focus of Chainguard, our
+comprehensive use of Knative and the  numerous contributors we employ in the
+company make us an ideal candidate for the End User seat.
+
+I am really excited at the prospect of serving as a relay between the project
+and the user community, especially given the great feedback that Chainguard
+can provide.


### PR DESCRIPTION
Adding Adolfo García Veytia's profile from Chainguard as a candidate for the EU elections.

Signed-off-by: Adolfo Garcia Veytia (puerco) <puerco@chainguard.dev>
