### PR TITLE
Fix permissions for .artifacthub repo

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -466,7 +466,7 @@ orgs:
         privacy: closed
         repos:
           # All repos should be listed here!
-          .artifacthub: write
+          .artifacthub: admin
           .github: admin
           actions: admin
           build: admin


### PR DESCRIPTION
@psschwei PTAL. I've just noticed that `admins` should definitely `admin` the repo. 