### PR TITLE
remove inactive members from prod group

### DIFF
--- a/groups/OWNERS
+++ b/groups/OWNERS
@@ -10,7 +10,6 @@ options:
 approvers:
 - dprotaso
 - upodroid
-- chizhg
 - kvmware
 
 reviewers:

--- a/groups/groups_test.go
+++ b/groups/groups_test.go
@@ -277,9 +277,7 @@ func TestNoDuplicateMembers(t *testing.T) {
 func TestHardcodedGroupsForParanoia(t *testing.T) {
 	groups := map[string][]string{
 		"kn-infra-gcp-org-admins@knative.dev": {
-			"chizhg@google.com",
 			"cy@borg.dev",
-			"chizhg@knative.team",
 			"cy@knative.team",
 			"hh@cncf.io",
 			"hh@knative.team",
@@ -315,7 +313,8 @@ func TestHardcodedGroupsForParanoia(t *testing.T) {
 // access to the group not only via gmail but also via web (you can see the list
 // and history of threads and also use web interface to operate the group)
 // More info:
-// 	https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups#allowWebPosting
+//
+//	https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups#allowWebPosting
 func TestGroupsWhichShouldSupportHistory(t *testing.T) {
 	groups := map[string]struct{}{
 		"wg-leads@knative.team": {},

--- a/groups/wg-productivity/groups.yaml
+++ b/groups/wg-productivity/groups.yaml
@@ -79,7 +79,7 @@ groups:
       - evana@vmware.com
       - evankanderson@knative.team
       - dprotaso@gmail.com
-       - paul@paulschweigert.com
+      - paul@paulschweigert.com
       - paulschw@us.ibm.com
     managers:
        - kmahapatra@vmware.com

--- a/groups/wg-productivity/groups.yaml
+++ b/groups/wg-productivity/groups.yaml
@@ -19,8 +19,6 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - chizhg@google.com
-      - chizhg@knative.team
       - cy@knative.team
       - racker-maha-66b7d200@gcp.rackspace.com # Mahamed Ali
       - cy@borg.dev # Mahamed Ali
@@ -54,18 +52,17 @@ groups:
       ReconcileMembers: "true"
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
     members:
-      - chizhg@google.com
       - kmahapatra@vmware.com
+      - cy@borg.dev # Mahamed Ali
 
-  - email-id: k8s-infra-rbac-perf-tests@knative.dev
-    name: k8s-infra-rbac-perf-tests
-    description: |-
-      Grants access to the shared community cluster perf-tests namespace
-    settings:
-      ReconcileMembers: "true"
-      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
-    members:
-      - nziada@vmware.com
+  # - email-id: k8s-infra-rbac-perf-tests@knative.dev
+  #   name: k8s-infra-rbac-perf-tests
+  #   description: |-
+  #     Grants access to the shared community cluster perf-tests namespace
+  #   settings:
+  #     ReconcileMembers: "true"
+  #     WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
+  #   members:
 
   ###
   ### Productivity WG related mailing lists
@@ -82,11 +79,8 @@ groups:
       - evana@vmware.com
       - evankanderson@knative.team
       - dprotaso@gmail.com
-      - mattmoor@knative.team
-      - mattomata@gmail.com
-      - n3wscott@knative.team
-      - paul@paulschweigert.com
+       - paul@paulschweigert.com
       - paulschw@us.ibm.com
     managers:
-      - chizhg@google.com
-      - kmahapatra@vmware.com
+       - kmahapatra@vmware.com
+       - cy@borg.dev # Mahamed Ali

--- a/groups/wg-productivity/groups.yaml
+++ b/groups/wg-productivity/groups.yaml
@@ -37,7 +37,7 @@ groups:
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # needed for RBAC
     members:
       - k8s-infra-rbac-prow@knative.dev
-      - k8s-infra-rbac-perf-tests@knative.dev
+      # - k8s-infra-rbac-perf-tests@knative.dev
 
   # GKE RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on a cluster


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Removing some inactive users from the productivity groups.

/assign @kvmware 