### PR TITLE
Drop paul, julz from security mailing list group

### DIFF
--- a/groups/wg-security/groups.yaml
+++ b/groups/wg-security/groups.yaml
@@ -11,10 +11,7 @@ groups:
       - evan.k.anderson@gmail.com
       - evana@vmware.com
       - evankanderson@knative.team
-      - julz.friedman@uk.ibm.com
-      - julz@knative.team
     members:
       - pablo@triggermesh.com
-      - paulschw@us.ibm.com
       - vaikas@gmail.com
 


### PR DESCRIPTION
# Changes

Follow up to #1312, dropping myself from the security mailing list in favor of David. Also dropping julz, as he's no longer active here.

/assign @evankanderson 