### PR TITLE
Fix @puerco affiliation and add to peribolos group configs

### DIFF
--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -96,10 +96,10 @@ first name):
 | -------------------------------------------------------------- | ------------------------- | ------------ | ---------------------------------------------------- | ---------- | --------
 | <img width="30px" src="https://github.com/csantanapr.png">     | Carlos Santana            | Independent  | [@csantanapr](https://github.com/csantanapr)         | 2021-12-02 | 2023     |
 | <img width="30px" src="https://github.com/lance.png">          | Lance Ball                | Red Hat      | [@lance](https://github.com/lance)                   | 2021-12-02 | 2023     |
-| <img width="30px" src="https://github.com/puerco.png">  | Adolfo García Veytia *        | Box          | [@puerco](https://github.com/puerco)   | 2023-02-16 | 2024     |
+| <img width="30px" src="https://github.com/puerco.png">  | Adolfo García Veytia *        | Chainguard          | [@puerco](https://github.com/puerco)   | 2023-02-16 | 2024     |
 | <img width="30px" src="https://github.com/nainaz.png">         | Naina Singh               | Red Hat      | [@nainaz](https://github.com/nainaz)                 | 2022-12-06 | 2024     |
 | <img width="30px" src="https://github.com/salaboy.png">        | Mauricio Salatino         | Diagrid       | [@salaboy](https://github.com/salaboy)               | 2022-12-06 | 2024     |
-> * Murugappan holds the End User seat
+> * Adolfo holds the End User seat
 ## Emeritus Committee Members
 
 To recognize the folks that have served in the SC in the past, below we list the previous members of the SC (sorted by their 'Term End').

--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -62,7 +62,6 @@ aliases:
   - dprotaso
   - dsimansk
   - evankanderson
-  - itsmurugappan
   - knative-automation
   - knative-prow-releaser-robot
   - knative-prow-robot
@@ -73,6 +72,7 @@ aliases:
   - mchmarny
   - nainaz
   - psschwei
+  - puerco
   - salaboy
   - smoser-ibm
   - upodroid
@@ -140,9 +140,9 @@ aliases:
   - psschwei
   steering-committee:
   - csantanapr
-  - itsmurugappan
   - lance
   - nainaz
+  - puerco
   - salaboy
   technical-oversight-committee:
   - dprotaso

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -18,6 +18,7 @@ orgs:
     - lance
     - nainaz
     - psschwei
+    - puerco
     - salaboy
     - thelinuxfoundation
     members:
@@ -520,6 +521,7 @@ orgs:
             - itsmurugappan
             - lance
             - nainaz
+            - puerco
             - salaboy
             privacy: closed
           Trademark Committee:

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -13,7 +13,6 @@ orgs:
     - csantanapr
     - dprotaso
     - evankanderson
-    - itsmurugappan
     - knative-prow-robot
     - lance
     - nainaz
@@ -60,6 +59,7 @@ orgs:
     - houshengbo
     - ikvmw
     - ImJasonH
+    - itsmurugappan
     - izabelacg
     - jberkus
     - jcrossley3
@@ -518,7 +518,6 @@ orgs:
             description: Knative Steering Committee
             maintainers:
             - csantanapr
-            - itsmurugappan
             - lance
             - nainaz
             - puerco


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

 :broom: Fix @puerco affiliation in `STEERING-COMMITTEE.md`
 :broom: Offboard @itsmurugappan from SC group and move their entry to members list (thank you!)
 :broom: Add @puerco to SC and org admins list 

/kind documentation

Part of https://github.com/knative/community/issues/1265
Supersedes #1267

/cc @salaboy @csantanapr 


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>

