### PR TITLE
Add `dsimansk` and `zroubalik` to admin group

### DIFF
--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -13,6 +13,7 @@ orgs:
     - cncf-ci
     - csantanapr
     - dprotaso
+    - dsimansk
     - evankanderson
     - itsmurugappan
     - knative-prow-robot
@@ -21,6 +22,7 @@ orgs:
     - psschwei
     - salaboy
     - thelinuxfoundation
+    - zroubalik
     members:
     - aavarghese
     - abrennan89
@@ -48,7 +50,6 @@ orgs:
     - davidhadas
     - devguyio
     - dilipgb
-    - dsimansk
     - duglin
     - eric-sap
     - gab-satchi
@@ -133,7 +134,6 @@ orgs:
     - zhanggbj
     - zhaojizhuang
     - ZhiminXiang
-    - zroubalik
     - kahirokunn
     repos:
       # NOTE: If you are adding a repo here, you may also want to grant repo

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -12,6 +12,7 @@ orgs:
     - cncf-ci
     - csantanapr
     - dprotaso
+    - dsimansk
     - evankanderson
     - knative-prow-robot
     - lance
@@ -20,6 +21,7 @@ orgs:
     - puerco
     - salaboy
     - thelinuxfoundation
+    - zroubalik
     members:
     - aavarghese
     - abrennan89
@@ -47,7 +49,6 @@ orgs:
     - devguyio
     - dilipgb
     - dolfolife
-    - dsimansk
     - duglin
     - eallred-google
     - gab-satchi
@@ -139,7 +140,6 @@ orgs:
     - zhanggbj
     - zhaojizhuang
     - ZhiminXiang
-    - zroubalik
     - kahirokunn
     repos:
       # NOTE: If you are adding a repo here, you may also want to grant repo


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- Add `dsimansk` and `zroubalik` to admin group

Per Slack thread: https://cloud-native.slack.com/archives/C04LY4M2G49/p1680518153699939

/hold
Adding hold for TOC or Steering members to check.

/cc @knative/steering-committee @knative/technical-oversight-committee 
/cc @zroubalik 
