### PR TITLE
Removed references to CIVS

### DIFF
--- a/elections/README.md
+++ b/elections/README.md
@@ -92,7 +92,6 @@ This document outlines how to conduct Knative elections. See [TOC election proce
 - Monitor groups for nominations
 - Update the community regularly
 - Post deadlines and reminders during the election season
-- Reissue ballots from CIVS to voters who might have not received their ballot.
 - It is impossible to see the results of the election until the election ends; for purposes of transparency with the community it is encouraged to release some statistics during the election (ie. “65% of the community has voted so far!”)
 
 

--- a/mechanics/SC.md
+++ b/mechanics/SC.md
@@ -73,8 +73,7 @@ requirements based on community feedback.
 # Election Process
 
 Elections will be held using a time-limited
-[Condorcet](https://en.wikipedia.org/wiki/Condorcet_method) ranking on
-[CIVS](http://civs.cs.cornell.edu/) using the
+[Condorcet](https://en.wikipedia.org/wiki/Condorcet_method) ranking using the
 [Schulze](https://en.wikipedia.org/wiki/Schulze_method) method. The top
 vote-getters will be elected to the open seats. This is the same process used
 for TOC elections.


### PR DESCRIPTION
 Removed references to CIVS, since we're no longer using it for any elections. This is just some minor cleanup while we prepare for the TOC election.