### PR TITLE
Fix two broken links in ROLES.md

### DIFF
--- a/ROLES.md
+++ b/ROLES.md
@@ -136,8 +136,8 @@ this is not a requirement.
 ### Requirements
 
 - Member of the Knative github org. Create a PR adding you to
-[knative.yaml](../peribolos/knative.yaml) and/or to
-[knative-sandbox.yaml](../peribolos/knative-sandbox.yaml) which after when
+[knative.yaml](../main/peribolos/knative.yaml) and/or to
+[knative-sandbox.yaml](../main/peribolos/knative-sandbox.yaml) which after when
 merged will send you an invite that you have to accept to become a member
 of these organizations.
 


### PR DESCRIPTION
# Changes

   Fix two broken links in ROLES.md
 - Expect correct links
        - https://github.com/knative/community/blob/main/peribolos/knative.yaml 
        - https://github.com/knative/community/blob/main/peribolos/knative-sandbox.yaml 

 - Current links, which route to empty page instead of right one
        - https://github.com/knative/community/blob/peribolos/knative.yaml
        - https://github.com/knative/community/blob/peribolos/knative-sandbox.yaml

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/documentation <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
