### PR TITLE
2023 TOC election results

### DIFF
--- a/elections/2023-TOC/results.md
+++ b/elections/2023-TOC/results.md
@@ -1,0 +1,13 @@
+## 2023 TOC Member Election Results
+
+We are happy to announce the results of the 2023 Knative Technical Oversight Committee (TOC) election results!
+
+Please welcome Krsna Mahapatra as the new TOC member. Krsna will serve a 2 year term ending in 2025 starting immediately. Krsna will serve together with current TOC members Dave Protasowski, David Simansky, Zbynek Roubalik and Paul Schweigert.
+
+We would also like to take this opportunity to express our sincere appreciation to Evan Anderson. His tireless efforts and invaluable contributions to our community during his tenure was truly remarkable. He has played an integral role in shaping our community, and we owe him a debt of gratitude for his service.
+
+Cheers,
+Dawn Foster and Ali Ok
+TOC Election Officers
+To contact us, email elections@knative.team
+


### PR DESCRIPTION
As suggested in https://github.com/knative/community/tree/main/elections#process, publishing 2023 TOC election results, so that it shows up in Elekto properly.

Text copied from the SC announment.