### PR TITLE
Add Krsna to TOC and infra WG leads as admins

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -152,7 +152,7 @@ aliases:
   technical-oversight-committee:
   - dprotaso
   - dsimansk
-  - evankanderson
+  - kvmware
   - psschwei
   - zroubalik
   trademark-committee:

--- a/peribolos/knative-sandbox-OWNERS_ALIASES
+++ b/peribolos/knative-sandbox-OWNERS_ALIASES
@@ -166,7 +166,6 @@ aliases:
   - csantanapr
   - dprotaso
   - dsimansk
-  - evankanderson
   - itsmurugappan
   - knative-automation
   - knative-prow-releaser-robot
@@ -274,7 +273,7 @@ aliases:
   technical-oversight-committee:
   - dprotaso
   - dsimansk
-  - evankanderson
+  - kvmware
   - psschwei
   - zroubalik
   ux-wg-leads:

--- a/peribolos/knative-sandbox.yaml
+++ b/peribolos/knative-sandbox.yaml
@@ -14,7 +14,6 @@ orgs:
     - csantanapr
     - dprotaso
     - dsimansk
-    - evankanderson
     - itsmurugappan
     - knative-prow-robot
     - lance
@@ -23,6 +22,8 @@ orgs:
     - salaboy
     - thelinuxfoundation
     - zroubalik
+    - kvmware
+    - upodroid
     members:
     - aavarghese
     - aliok
@@ -53,6 +54,7 @@ orgs:
     - dilipgb
     - duglin
     - eric-sap
+    - evankanderson
     - gab-satchi
     - gabo1208
     - haubenr
@@ -78,7 +80,6 @@ orgs:
     - knative-prow-updater-robot
     - knative-test-reporter-robot
     - krithika369
-    - kvmware
     - lberk
     - lionelvillard
     - liuchangyan
@@ -124,7 +125,6 @@ orgs:
     - thisisnotapril
     - travis-minke-sap
     - tzununbekov
-    - upodroid
     - vagababov
     - vaibhavjainwiz
     - vaikas
@@ -707,11 +707,11 @@ orgs:
           Technical Oversight Committee:
             description: Members of the Knative Technical Oversight Committee (TOC)
             maintainers:
-            - evankanderson
             - dprotaso
             - dsimansk
             - zroubalik
             - psschwei
+            - kvmware
             privacy: closed
           Knative Release Leads:
             privacy: closed

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -13,7 +13,6 @@ orgs:
     - csantanapr
     - dprotaso
     - dsimansk
-    - evankanderson
     - knative-prow-robot
     - lance
     - nainaz
@@ -22,6 +21,8 @@ orgs:
     - salaboy
     - thelinuxfoundation
     - zroubalik
+    - kvmware
+    - upodroid
     members:
     - aavarghese
     - aliok
@@ -52,6 +53,7 @@ orgs:
     - dolfolife
     - duglin
     - eallred-google
+    - evankanderson
     - gab-satchi
     - gabo1208
     - gauron99
@@ -82,7 +84,6 @@ orgs:
     - knative-prow-updater-robot
     - knative-test-reporter-robot
     - krithika369
-    - kvmware
     - lberk
     - lionelvillard
     - liuchangyan
@@ -130,7 +131,6 @@ orgs:
     - travis-minke-sap
     - trisberg
     - tzununbekov
-    - upodroid
     - vagababov
     - vaikas
     - vdemeester
@@ -537,11 +537,11 @@ orgs:
           Technical Oversight Committee:
             description: Members of the Knative Technical Oversight Committee (TOC)
             maintainers:
-            - evankanderson
             - dprotaso
             - dsimansk
             - zroubalik
             - psschwei
+            - kvmware
             privacy: closed
           Knative Release Leads:
             privacy: closed


### PR DESCRIPTION
part of https://github.com/knative/community/issues/1369

Note adding Mahamad and Krsna as org admins to handle knative-sandbox rename (https://github.com/knative/community/issues/169)