### PR TITLE
Allow anyone to send emails to `automation@knative.team`

### DIFF
--- a/groups/wg-productivity/groups.yaml
+++ b/groups/wg-productivity/groups.yaml
@@ -86,10 +86,11 @@ groups:
   - email-id: automation@knative.team
     name: automation
     description: |-
-      User group for administrators of knative-automation.
+      User group for administrators of Knative GitHub bots
     settings:
       AllowExternalMembers: "true"
       ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
     owners:
       - evana@vmware.com
       - evankanderson@knative.team


### PR DESCRIPTION
/cc @kvmware @dprotaso @evankanderson @psschwei

I configured @knative-prow-updater-robot's email to be automation+prow-updater-robot@knative.team but the group wasn't receiving public emails. This change should fix it.
