### PR TITLE
Hand off VMware trademark seat to Sameer

### DIFF
--- a/TRADEMARK-COMMITTEE.md
+++ b/TRADEMARK-COMMITTEE.md
@@ -75,11 +75,11 @@ the trademark committee invites your feedback there. See
 
 ## Committee Members
 
-| Member        | Organization | Profile                                            |
-| ------------- | ------------ | -------------------------------------------------- |
-| Mark Chmarny  | Google       | [@mchmarny](https://github.com/mchmarny)           |
-| Simon Moser   | IBM/RedHat   | [@smoser-ibm](https://github.com/smoser-ibm)       |
-| Evan Anderson | VMware       | [@evankanderson](https://github.com/evankanderson) |
+| Member        | Organization | Profile                                                        |
+| ------------- | ------------ | -------------------------------------------------------------- |
+| Mark Chmarny  | Google       | [@mchmarny](https://github.com/mchmarny)                       |
+| Simon Moser   | IBM/RedHat   | [@smoser-ibm](https://github.com/smoser-ibm)                   |
+| Sameer Vohra  | VMware       | [@xtreme-sameer-vohra](https://github.com/xtreme-sameer-vohra) |
 
 ## Decision process
 

--- a/groups/committee-trademark/groups.yaml
+++ b/groups/committee-trademark/groups.yaml
@@ -8,8 +8,7 @@ groups:
       ReconcileMembers: "true"
     owners:
       # VMware
-      - evankanderson@knative.team
-      - evana@vmware.com
+      - vsameer@vmware.com
       # IBM / RedHat
       - sdmoser@googlemail.com
       - SMOSER@de.ibm.com

--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -156,7 +156,7 @@ aliases:
   - psschwei
   - zroubalik
   trademark-committee:
-  - evankanderson
+  - xtreme-sameer-vohra
   - mchmarny
   - smoser-ibm
   ux-wg-leads:

--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -59,7 +59,6 @@ aliases:
   - csantanapr
   - dprotaso
   - dsimansk
-  - evankanderson
   - knative-automation
   - knative-prow-releaser-robot
   - knative-prow-robot
@@ -76,6 +75,7 @@ aliases:
   - salaboy
   - smoser-ibm
   - upodroid
+  - xtreme-sameer-vohra
   - zroubalik
   knative-release-leads:
   - dsimansk
@@ -156,9 +156,9 @@ aliases:
   - psschwei
   - zroubalik
   trademark-committee:
-  - xtreme-sameer-vohra
   - mchmarny
   - smoser-ibm
+  - xtreme-sameer-vohra
   ux-wg-leads:
   - snneji
   ux-writers:

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -530,7 +530,7 @@ orgs:
           Trademark Committee:
             description: Knative Trademark Committee
             maintainers:
-            - evankanderson
+            - xtreme-sameer-vohra
             - smoser-ibm
             - mchmarny
             privacy: closed


### PR DESCRIPTION
Since Trademark seats are based on company affiliation, hand off the VMware seat to Sameer now that I've left VMware.