### PR TITLE
adding skonto, nak3 and retocode as docs reviewers+writers

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -20,13 +20,19 @@ aliases:
   - salaboy
   docs-reviewers:
   - nainaz
+  - nak3
   - pmbanugo
+  - retocode
+  - skonto
   - snneji
   docs-wg-leads:
   - snneji
   docs-writers:
   - csantanapr
+  - nak3
   - psschwei
+  - retocode
+  - skonto
   - snneji
   eventing-reviewers:
   - aslom

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -402,6 +402,9 @@ orgs:
         - snneji
         - pmbanugo
         - nainaz
+        - skonto
+        - retocode
+        - nak3
       Docs Writers:
         description: Grants write access to docs-related repositories.
         privacy: closed
@@ -418,6 +421,9 @@ orgs:
         members:
         - psschwei
         - csantanapr
+        - skonto
+        - retocode
+        - nak3
       Eventing Reviewers:
         description: Receive reviews for eventing related repositories
         privacy: closed


### PR DESCRIPTION
# Changes
- Adding @nak3 , @skonto and @ReToCode as reviewers + writers to knative/docs

# Reasoning
Docs is without a working group lead and current approvers are not really active anymore, so PRs pile up or take a long time to be merged. We would like to help out.

/assign @dprotaso, @psschwei  