### PR TITLE
Update function working group lead

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -60,7 +60,7 @@ aliases:
   - salaboy
   - zroubalik
   functions-wg-leads:
-  - lance
+  - lkingland
   - salaboy
   knative-admin:
   - Vishal-Chdhry

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -465,11 +465,11 @@ orgs:
           Functions WG Leads:
             description: The Working Group leads for Functions
             members:
-            - lance
+            - lkingland
             - salaboy
             privacy: closed
         members:
-          - lkingland
+          - lance
           - matejvasek
           - zroubalik
           - jrangelramos
@@ -669,7 +669,7 @@ orgs:
             members:
             - nak3
             - skonto
-            - psschwei            
+            - psschwei
             privacy: closed
           Serving WG Leads:
             description: The Working Group leads for Serving

--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -211,8 +211,13 @@ Knative Functions [CLI](https://github.com/knative/func), API, and [language pac
 
 | &nbsp;                                                           | Leads           | Company | Profile                                           |
 | ---------------------------------------------------------------- | --------------- | ------- | ------------------------------------------------- |
-| <img width="30px" src="https://github.com/lance.png"> | Lance Ball    | Red Hat     | [lance](https://github.com/lance) |
+| <img width="30px" src="https://github.com/lkingland.png"> | Luke Kingland    | Red Hat     | [lkingland](https://github.com/lkingland) |
 | <img width="30px" src="https://github.com/salaboy.png"> | Mauricio Salatino    | VMWare     | [salaboy](https://github.com/salaboy) |
+
+| &nbsp;                                                     | Emeritus Leads | Profile                                     | Duration  |
+| ---------------------------------------------------------- | -------------- | ------------------------------------------- | --------- |
+| <img width="30px" src="https://github.com/lance.png">   | Lance Ball    | [lance](https://github.com/lance)     | 2022-2023 |
+
 
 ## Operations
 

--- a/working-groups/functions/CHARTER.md
+++ b/working-groups/functions/CHARTER.md
@@ -33,5 +33,5 @@ By providing higher-level abstractions through functions, the working group aims
 - Mauricio Salatino - VMWare
 
 ## Roadmap
-https://github.com/orgs/knative-sandbox/projects/7
+https://github.com/orgs/knative/projects/49
 


### PR DESCRIPTION
This commit updates the working group lead information for Knative Functions, naming @lkingland as the lead in place of @lance who will be stepping down from the lead role.

Also corrects the project link in the Functions working group charter document.