### PR TITLE
Drop the go policy consistency clause

### DIFF
--- a/mechanics/GOLANG-POLICY.md
+++ b/mechanics/GOLANG-POLICY.md
@@ -18,11 +18,6 @@ runtime.
 CI systems (Prow and Github Actions) should try to always be on the most recent patch
 level.
 
-## Consistency
-
-All repositories should depend on the same Golang version, evidenced in their respective
-`go.mod` file.
-
 ## Caution
 
 Major Golang version bumps (i.e. 1.14 to 1.15) should be made deliberately and should not


### PR DESCRIPTION
The version in the go.mod file is the min go version required to
build the repository. We should always be using the new version
of the tool chain

Dropping this clause is a reflection of what we are doing today
