### PR TITLE
Add lkingland to WG leads and calendar maintainers

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -41,6 +41,7 @@ groups:
       - knakayam@redhat.com
       - krsna@knative.team
       - lionelvillard@knative.team
+      - lkinglan@redhat.com
       - matzew@knative.team
       - mwessend@redhat.com
       - mwessendorf@gmail.com
@@ -68,6 +69,7 @@ groups:
       - pmorie@knative.team
       - csantana23@gmail.com
       - lball@knative.team
+      - lkinglan@redhat.com
       - puerco@chainguard.dev
       - naina.sng@gmail.com
       - salaboy@gmail.com


### PR DESCRIPTION
Updates WG Lead and calendar maintainer emails list to include @lkingland (see also #1413)