### PR TITLE
Remove link to serving AUTHORS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ using Knative.
 
 Knative is an open source project with an active development community. The
 project was started by Google but has contributions from a growing number of
-industry-leading companies. For a current list of the authors, see
-[Authors](https://github.com/knative/serving/blob/main/AUTHORS).
+industry-leading companies.
 
 ### Authoring samples
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

# Changes

/kind documentation

- :broom: Removes a link from the main README to the AUTHORs file that [was removed](https://github.com/knative/serving/pull/14350) from the serving repo.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind documentation

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

Follow up to https://github.com/knative/community/issues/141
/cc @knative/steering-committee 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
NONE
```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
