### PR TITLE
Align org admins of knative and knative-extensions

### DIFF
--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -14,11 +14,11 @@ orgs:
     - csantanapr
     - dprotaso
     - dsimansk
-    - itsmurugappan
     - knative-prow-robot
     - lance
     - nainaz
     - psschwei
+    - puerco
     - salaboy
     - thelinuxfoundation
     - kvmware
@@ -63,6 +63,7 @@ orgs:
     - hhk7734
     - houshengbo
     - ikvmw
+    - itsmurugappan
     - izabelacg
     - jcrossley3
     - jkjell


### PR DESCRIPTION
Per my previous PR adding David to TOC charter. I've noticed admin groups for our organization don't match.

/cc @knative/technical-oversight-committee 
/cc @knative/productivity-leads 