### PR TITLE
Update support window mentioned in the MATURITY-LEVELS.md

### DIFF
--- a/mechanics/MATURITY-LEVELS.md
+++ b/mechanics/MATURITY-LEVELS.md
@@ -120,7 +120,7 @@ declaration that the project will no longer managed or maintained. For a project
 which is currently in the "stable" phase, there should be a clear commitment to
 support the project with bug and security fixes as applicable
 [based on the Knative release principles](https://github.com/knative/community/blob/master/mechanics/RELEASE-VERSIONING-PRINCIPLES.md)
-(4 versions of Knative).
+(2 versions of Knative).
 
 # Migration to Core
 


### PR DESCRIPTION
Look like we forgot to update one place in the docs when we changed the release cadence to quarterly.

Original PR: https://github.com/knative/community/pull/1155

This implies we support sunset features in older releases until they EOL.

Note: Our support contract is currently 2 releases now - this PR isn't changing that. That was decided in https://github.com/knative/community/issues/1096


