### PR TITLE
Update SC members and SC permissions

### DIFF
--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -106,11 +106,8 @@ To recognize the folks that have served in the SC in the past, below we list the
 
 | &nbsp;                                                         | Member              | Profile                                              | Term Start | Term End |
 | -------------------------------------------------------------- | ------------------- |------------------------------------------------------|------------| -------- |
-| <img width="30px" src="https://github.com/csantanapr.png">     | Carlos Santana      | [@csantanapr](https://github.com/csantanapr)         | 2021       | 2023     |
-| <img width="30px" src="https://github.com/lance.png">          | Lance Ball          | [@lance](https://github.com/lance)                   | 2021       | 2023     |
 | <img width="30px" src="https://github.com/dewitt.png">         | Dewitt Clinton      | [@dewitt](https://github.com/dewitt)                 | Bootstrap  | 2019     |
 | <img width="30px" src="https://github.com/mchmarny.png">       | Mark Charmny        | [@mchmarny](https://github.com/mchmarny)             | Bootstrap  | 2019     |
-| <img width="30px" src="https://github.com/itsmurugappan.png">  | Murugappan Chetty   | [@itsmurugappan](https://github.com/itsmurugappan)   | 2022       | 2023     |
 | <img width="30px" src="https://github.com/jdumars.png">        | Jaice Singer DuMars | [@jdumars](https://github.com/jdumars)               | 2019       | 2020     |
 | <img width="30px" src="https://github.com/lindydonna.png">     | Donna Malayeri      | [@lindydonna](https://github.com/lindydonna)         | 2019       | 2020     |
 | <img width="30px" src="https://github.com/rgregg.png">         | Ryan Gregg          | [@rgregg](https://github.com/rgregg)                 | Bootstrap  | 2020     |
@@ -122,6 +119,9 @@ To recognize the folks that have served in the SC in the past, below we list the
 | <img width="30px" src="https://github.com/vaikas.png">         | Ville Aikas         | [@vaikas](https://github.com/vaikas)                 | 2020       | 2022     |
 | <img width="30px" src="https://github.com/pmorie.png">         | Paul Morie          | [@pmorie](https://github.com/pmorie)                 | 2020       | 2022     |
 | <img width="30px" src="https://github.com/thisisnotapril.png"> | April Kyle Nassi    | [@thisisnotapril](https://github.com/thisisnotapril) | Bootstrap  | 2022     |
+| <img width="30px" src="https://github.com/itsmurugappan.png">  | Murugappan Chetty   | [@itsmurugappan](https://github.com/itsmurugappan)   | 2022       | 2023     |
+| <img width="30px" src="https://github.com/csantanapr.png">     | Carlos Santana      | [@csantanapr](https://github.com/csantanapr)         | 2021       | 2023     |
+| <img width="30px" src="https://github.com/lance.png">          | Lance Ball          | [@lance](https://github.com/lance)                   | 2021       | 2023     |
 
 ## Decision process
 

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -92,34 +92,36 @@ employer.
 The current membership of the committee is currently (listed alphabetically by
 first name):
 
-| &nbsp;                                                         | Member                    | Organization | Profile                                              | Term Start | Term End |
-| -------------------------------------------------------------- | ------------------------- | ------------ | ---------------------------------------------------- | ---------- | --------
-| <img width="30px" src="https://github.com/csantanapr.png">     | Carlos Santana            | Independent  | [@csantanapr](https://github.com/csantanapr)         | 2021-12-02 | 2023     |
-| <img width="30px" src="https://github.com/lance.png">          | Lance Ball                | Red Hat      | [@lance](https://github.com/lance)                   | 2021-12-02 | 2023     |
-| <img width="30px" src="https://github.com/puerco.png">  | Adolfo García Veytia *        | Chainguard          | [@puerco](https://github.com/puerco)   | 2023-02-16 | 2024     |
-| <img width="30px" src="https://github.com/nainaz.png">         | Naina Singh               | Red Hat      | [@nainaz](https://github.com/nainaz)                 | 2022-12-06 | 2024     |
-| <img width="30px" src="https://github.com/salaboy.png">        | Mauricio Salatino         | Diagrid       | [@salaboy](https://github.com/salaboy)               | 2022-12-06 | 2024     |
+| &nbsp;                                                        | Member                 | Organization | Profile                                            | Term Start | Term End |
+|---------------------------------------------------------------|------------------------|--------------|----------------------------------------------------|------------|----------|
+| <img width="30px" src="https://github.com/puerco.png">        | Adolfo García Veytia * | Chainguard   | [@puerco](https://github.com/puerco)               | 2023-02-16 | 2024     |
+| <img width="30px" src="https://github.com/aliok.png">         | Ali Ok                 | Red Hat      | [@aliok](https://github.com/aliok)                 | 2023-11-28 | 2025     |
+| <img width="30px" src="https://github.com/evankanderson.png"> | Evan Anderson          | VMware       | [@evankanderson](https://github.com/evankanderson) | 2023-11-28 | 2025     |
+| <img width="30px" src="https://github.com/nainaz.png">        | Naina Singh            | Red Hat      | [@nainaz](https://github.com/nainaz)               | 2022-12-06 | 2024     |
+| <img width="30px" src="https://github.com/salaboy.png">       | Mauricio Salatino      | Diagrid      | [@salaboy](https://github.com/salaboy)             | 2022-12-06 | 2024     |
 > * Adolfo holds the End User seat
 ## Emeritus Committee Members
 
 To recognize the folks that have served in the SC in the past, below we list the previous members of the SC (sorted by their 'Term End').
 
-| &nbsp;                                                         | Member              | Profile                                               | Term Start | Term End |
-| -------------------------------------------------------------- | ------------------- | ----------------------------------------------------- | ---------- | --------
-| <img width="30px" src="https://github.com/dewitt.png">         | Dewitt Clinton      | [@dewitt](https://github.com/dewitt)                  | Bootstrap  | 2019     |
-| <img width="30px" src="https://github.com/mchmarny.png">       | Mark Charmny        | [@mchmarny](https://github.com/mchmarny)              | Bootstrap  | 2019     |
-| <img width="30px" src="https://github.com/itsmurugappan.png">  | Murugappan Chetty   | [@itsmurugappan](https://github.com/itsmurugappan)          | 2022 | 2023     |
-| <img width="30px" src="https://github.com/jdumars.png">        | Jaice Singer DuMars | [@jdumars](https://github.com/jdumars)                | 2019       | 2020     |
-| <img width="30px" src="https://github.com/lindydonna.png">     | Donna Malayeri      | [@lindydonna](https://github.com/lindydonna)          | 2019       | 2020     |
-| <img width="30px" src="https://github.com/rgregg.png">         | Ryan Gregg          | [@rgregg](https://github.com/rgregg)                  | Bootstrap  | 2020     |
-| <img width="30px" src="https://github.com/isdal.png">          | Tomas Isdal         | [@isdal](https://github.com/isdal)                    | Bootstrap  | 2020     |
-| <img width="30px" src="https://github.com/anicolao.png">       | Alex Nicolau        | [@anicolao](https://github.com/anicolao)              | 2020       | 2020     |
-| <img width="30px" src="https://github.com/ronavn.png">         | Ron Avnur           | [@ronavn](https://github.com/ronavn)                  | 2020       | 2020     |
-| <img width="30px" src="https://github.com/bsnchan.png">        | Brenda Chan         | [@bsnchan](https://github.com/bsnchan)                | Bootstrap  | 2021     |
-| <img width="30px" src="https://github.com/mbehrendt.png">      | Michael Behrendt    | [@mbehrendt](https://github.com/mbehrendt)            | Bootstrap  | 2021     |
-| <img width="30px" src="https://github.com/vaikas.png">         | Ville Aikas         | [@vaikas](https://github.com/vaikas)                  | 2020       | 2022     |
-| <img width="30px" src="https://github.com/pmorie.png">         | Paul Morie          | [@pmorie](https://github.com/pmorie)                  | 2020       | 2022     |
-| <img width="30px" src="https://github.com/thisisnotapril.png"> | April Kyle Nassi    | [@thisisnotapril](https://github.com/thisisnotapril)  | Bootstrap  | 2022     |
+| &nbsp;                                                         | Member              | Profile                                              | Term Start | Term End |
+| -------------------------------------------------------------- | ------------------- |------------------------------------------------------|------------| -------- |
+| <img width="30px" src="https://github.com/csantanapr.png">     | Carlos Santana      | [@csantanapr](https://github.com/csantanapr)         | 2021       | 2023     |
+| <img width="30px" src="https://github.com/lance.png">          | Lance Ball          | [@lance](https://github.com/lance)                   | 2021       | 2023     |
+| <img width="30px" src="https://github.com/dewitt.png">         | Dewitt Clinton      | [@dewitt](https://github.com/dewitt)                 | Bootstrap  | 2019     |
+| <img width="30px" src="https://github.com/mchmarny.png">       | Mark Charmny        | [@mchmarny](https://github.com/mchmarny)             | Bootstrap  | 2019     |
+| <img width="30px" src="https://github.com/itsmurugappan.png">  | Murugappan Chetty   | [@itsmurugappan](https://github.com/itsmurugappan)   | 2022       | 2023     |
+| <img width="30px" src="https://github.com/jdumars.png">        | Jaice Singer DuMars | [@jdumars](https://github.com/jdumars)               | 2019       | 2020     |
+| <img width="30px" src="https://github.com/lindydonna.png">     | Donna Malayeri      | [@lindydonna](https://github.com/lindydonna)         | 2019       | 2020     |
+| <img width="30px" src="https://github.com/rgregg.png">         | Ryan Gregg          | [@rgregg](https://github.com/rgregg)                 | Bootstrap  | 2020     |
+| <img width="30px" src="https://github.com/isdal.png">          | Tomas Isdal         | [@isdal](https://github.com/isdal)                   | Bootstrap  | 2020     |
+| <img width="30px" src="https://github.com/anicolao.png">       | Alex Nicolau        | [@anicolao](https://github.com/anicolao)             | 2020       | 2020     |
+| <img width="30px" src="https://github.com/ronavn.png">         | Ron Avnur           | [@ronavn](https://github.com/ronavn)                 | 2020       | 2020     |
+| <img width="30px" src="https://github.com/bsnchan.png">        | Brenda Chan         | [@bsnchan](https://github.com/bsnchan)               | Bootstrap  | 2021     |
+| <img width="30px" src="https://github.com/mbehrendt.png">      | Michael Behrendt    | [@mbehrendt](https://github.com/mbehrendt)           | Bootstrap  | 2021     |
+| <img width="30px" src="https://github.com/vaikas.png">         | Ville Aikas         | [@vaikas](https://github.com/vaikas)                 | 2020       | 2022     |
+| <img width="30px" src="https://github.com/pmorie.png">         | Paul Morie          | [@pmorie](https://github.com/pmorie)                 | 2020       | 2022     |
+| <img width="30px" src="https://github.com/thisisnotapril.png"> | April Kyle Nassi    | [@thisisnotapril](https://github.com/thisisnotapril) | Bootstrap  | 2022     |
 
 ## Decision process
 

--- a/groups/committee-steering/groups.yaml
+++ b/groups/committee-steering/groups.yaml
@@ -7,9 +7,10 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - csantana23@gmail.com
-      - lball@redhat.com
-      - lball@knative.team
+      - aliok@redhat.com
+      - evan.k.anderson@gmail.com
+      - evana@vmware.com
+      - evankanderson@knative.team
       - puerco@chainguard.dev
       - naina.sng@gmail.com
       - salaboy@gmail.com

--- a/groups/committee-steering/groups.yaml
+++ b/groups/committee-steering/groups.yaml
@@ -9,8 +9,6 @@ groups:
     owners:
       - aliok@redhat.com
       - evan.k.anderson@gmail.com
-      - evana@vmware.com
-      - evankanderson@knative.team
       - puerco@chainguard.dev
       - naina.sng@gmail.com
       - salaboy@gmail.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -68,8 +68,6 @@ groups:
     owners:
       - aliok@redhat.com
       - evan.k.anderson@gmail.com
-      - evana@vmware.com
-      - evankanderson@knative.team
       - lkinglan@redhat.com
       - puerco@chainguard.dev
       - naina.sng@gmail.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -66,9 +66,10 @@ groups:
       AllowExternalMembers: "false"
       WhoCanPostMessage: "ANYONE_CAN_POST"
     owners:
-      - pmorie@knative.team
-      - csantana23@gmail.com
-      - lball@knative.team
+      - aliok@redhat.com
+      - evan.k.anderson@gmail.com
+      - evana@vmware.com
+      - evankanderson@knative.team
       - lkinglan@redhat.com
       - puerco@chainguard.dev
       - naina.sng@gmail.com

--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -67,18 +67,18 @@ aliases:
   knative-admin:
   - Cali0707
   - ReToCode
+  - aliok
   - creydr
-  - csantanapr
   - davidhadas
   - dprotaso
   - dsimansk
+  - evankanderson
   - knative-automation
   - knative-prow-releaser-robot
   - knative-prow-robot
   - knative-prow-updater-robot
   - knative-test-reporter-robot
   - krsna-m
-  - lance
   - mchmarny
   - nainaz
   - pierDipi
@@ -157,8 +157,8 @@ aliases:
   - psschwei
   - skonto
   steering-committee:
-  - csantanapr
-  - lance
+  - aliok
+  - evankanderson
   - nainaz
   - puerco
   - salaboy

--- a/peribolos/knative-extensions-OWNERS_ALIASES
+++ b/peribolos/knative-extensions-OWNERS_ALIASES
@@ -169,22 +169,22 @@ aliases:
   knative-admin:
   - Cali0707
   - ReToCode
+  - aliok
   - creydr
-  - csantanapr
   - davidhadas
   - dprotaso
   - dsimansk
-  - itsmurugappan
+  - evankanderson
   - knative-automation
   - knative-prow-releaser-robot
   - knative-prow-robot
   - knative-prow-updater-robot
   - knative-test-reporter-robot
   - krsna-m
-  - lance
   - nainaz
   - pierDipi
   - psschwei
+  - puerco
   - salaboy
   - skonto
   - upodroid
@@ -274,10 +274,10 @@ aliases:
   - psschwei
   - skonto
   steering-committee:
-  - csantanapr
-  - itsmurugappan
-  - lance
+  - aliok
+  - evankanderson
   - nainaz
+  - puerco
   - salaboy
   technical-oversight-committee:
   - davidhadas

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -9,14 +9,14 @@ orgs:
     members_can_create_repositories: false
     default_repository_permission: read
     admins:
+    - aliok
     - caniszczyk
     - cncf-ci
-    - csantanapr
     - davidhadas
     - dprotaso
     - dsimansk
+    - evankanderson
     - knative-prow-robot
-    - lance
     - nainaz
     - psschwei
     - puerco
@@ -27,7 +27,6 @@ orgs:
     members:
     - aavarghese
     - alexagriffith
-    - aliok
     - andrew-su
     - AngeloDanducci
     - aslom
@@ -47,6 +46,7 @@ orgs:
     - coryrc
     - cr22rc
     - creydr
+    - csantanapr
     - Cynocracy
     - daisy-ycguo
     - dan-j
@@ -56,7 +56,6 @@ orgs:
     - dolfolife
     - duglin
     - eric-sap
-    - evankanderson
     - gab-satchi
     - gabo1208
     - haubenr
@@ -84,6 +83,7 @@ orgs:
     - knative-prow-updater-robot
     - knative-test-reporter-robot
     - krithika369
+    - lance
     - lberk
     - lionelvillard
     - liuchangyan
@@ -729,10 +729,10 @@ orgs:
           Steering Committee:
             description: ""
             maintainers:
-            - csantanapr
-            - itsmurugappan
-            - lance
+            - aliok
+            - evankanderson
             - nainaz
+            - puerco
             - salaboy
             privacy: closed
           Technical Oversight Committee:

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -8,14 +8,14 @@ orgs:
     members_can_create_repositories: false
     default_repository_permission: read
     admins:
+    - aliok
     - caniszczyk
     - cncf-ci
-    - csantanapr
     - davidhadas
     - dprotaso
     - dsimansk
+    - evankanderson
     - knative-prow-robot
-    - lance
     - nainaz
     - psschwei
     - puerco
@@ -26,7 +26,6 @@ orgs:
     members:
     - aavarghese
     - alexagriffith
-    - aliok
     - andrew-su
     - AngeloDanducci
     - aslom
@@ -45,6 +44,7 @@ orgs:
     - coryrc
     - cr22rc
     - creydr
+    - csantanapr
     - Cynocracy
     - daisy-ycguo
     - debasishbsws
@@ -53,7 +53,6 @@ orgs:
     - dolfolife
     - duglin
     - eallred-google
-    - evankanderson
     - gab-satchi
     - gabo1208
     - gauron99
@@ -84,6 +83,7 @@ orgs:
     - knative-prow-updater-robot
     - knative-test-reporter-robot
     - krithika369
+    - lance
     - lberk
     - lionelvillard
     - liuchangyan
@@ -533,8 +533,8 @@ orgs:
           Steering Committee:
             description: Knative Steering Committee
             maintainers:
-            - csantanapr
-            - lance
+            - aliok
+            - evankanderson
             - nainaz
             - puerco
             - salaboy


### PR DESCRIPTION
The SC election results were [announced today](https://groups.google.com/g/knative-dev/c/oO8Xtw3i-Q4), this PR updates the relevant configurations.

# Changes
- Add @aliok and @evankanderson as new members
- Remove @lance and @csantanapr

Partially #1468
