### PR TITLE
Drop emeritus leads from various group

### DIFF
--- a/groups/committee-oversight/groups.yaml
+++ b/groups/committee-oversight/groups.yaml
@@ -9,13 +9,8 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - evankanderson@knative.team
-      - evana@vmware.com
-      - evan.k.anderson@gmail.com
       - david.hadas@gmail.com
       - dprotaso@gmail.com
-      - zroubalik@gmail.com
-      - zroubali@redhat.com
       - dsimansk@redhat.com
       - d.simansky@gmail.com
       - paul@paulschweigert.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -28,6 +28,8 @@ groups:
       - navidshaikh@knative.team
       - nshaikh@redhat.com
       - pierdipi@knative.team
+      - rhuss@knative.team
+      - rhuss@redhat.com
       - shou@us.ibm.com
 
   - email-id: calendar-maintainers@knative.team

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -15,48 +15,22 @@ groups:
       - evan.k.anderson@gmail.com
       - evana@vmware.com
       - evankanderson@knative.team
-      - julz.friedman@uk.ibm.com
-      - julz@knative.team
-      - markusthoemmes@knative.team
-      - markusthoemmes@me.com
-      - me.markusthoemmes@googlemail.com
-      - rhuss@knative.team
-      - rhuss@redhat.com
-      - tcnghia@gmail.com
       - paul@paulschweigert.com
       - paulschw@us.ibm.com
       - kmahapatra@vmware.com
     members:
-      - chizhg@google.com
-      - chizhg@knative.team
-      - csantanapr@knative.team
-      - devguyio@knative.team
       - dprotaso@knative.team
       - dsimansk@knative.team
       - dsimansk@redhat.com
-      - eng.a.abdalla@gmail.com
-      - fguardia@redhat.com
-      - grantr@knative.team
       - houshengbo@knative.team
-      - knakayam@redhat.com
       - krsna@knative.team
-      - lionelvillard@knative.team
       - lkinglan@redhat.com
-      - matzew@knative.team
-      - mwessend@redhat.com
-      - mwessendorf@gmail.com
-      - n3wscott@knative.team
-      - nak3@knative.team
       - navidshaikh@knative.team
       - nshaikh@redhat.com
-      - omerbensaadon@knative.team
       - pierdipi@knative.team
       - shou@us.ibm.com
-      - slinkydeveloper@knative.team
-      - snneji@knative.team
-      - travis.minke@sap.com
-      - vagababov@gmail.com
-      - villard@us.ibm.com
+
+
 
   - email-id: calendar-maintainers@knative.team
     name: calendar-maintainers

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -30,8 +30,6 @@ groups:
       - pierdipi@knative.team
       - shou@us.ibm.com
 
-
-
   - email-id: calendar-maintainers@knative.team
     name: calendar-maintainers
     description: |-


### PR DESCRIPTION
Noticed some of these files were a bit out of date, so took a best guess at who should be dropped. 

Wasn't sure if the admins for automation@knative.team are the TOC, so didn't update that one.

cc @knative/technical-oversight-committee @knative/productivity-leads 