### PR TITLE
Update min K8s versions in our release schedule

### DIFF
--- a/mechanics/RELEASE-SCHEDULE.md
+++ b/mechanics/RELEASE-SCHEDULE.md
@@ -23,9 +23,9 @@ With that said, it can be useful to have a list of when future releases will hap
 | Release | Date       | EOL        | Min K8s Version | Notes |
 | ------- | ---------- | ---------- | --------------- | ----- |
 | 1.13    | 2024-01-23 | 2024-07-30 | 1.27            |       |
-| 1.14    | 2024-04-23 | 2024-10-29 | -               |       |
+| 1.14    | 2024-04-23 | 2024-10-29 | 1.28            |       |
 | 1.15    | 2024-07-23 | 2025-01-28 | -               |       |
-| 1.16    | 2024-10-22 | 2025-04-29 | -               |       |
+| 1.16    | 2024-10-22 | 2025-04-29 | 1.29            |       |
 
 ## Releases supported by community
 


### PR DESCRIPTION
This flushes out the min K8s versions for the releases happening this year 

- 1.27 goes into maintenance mode 04-28
- 1.28 goes into maintenance mode 08-28

source: https://kubernetes.io/releases/patch-releases/

This follows the principal defined here - https://github.com/knative/community/blob/99eba74e558b1818cf079231c755ec5549f77775/mechanics/RELEASE-VERSIONING-PRINCIPLES.md#k8s-minimum-version-principle