### PR TITLE
Chainguard taking ownership of eventing-rabbitmq

### DIFF
--- a/peribolos/knative-extensions-OWNERS_ALIASES
+++ b/peribolos/knative-extensions-OWNERS_ALIASES
@@ -74,6 +74,7 @@ aliases:
   - lberk
   - matzew
   eventing-rabbitmq-approvers:
+  - gabo1208
   - tcnghia
   eventing-redis-approvers:
   - aavarghese

--- a/peribolos/knative-extensions-OWNERS_ALIASES
+++ b/peribolos/knative-extensions-OWNERS_ALIASES
@@ -74,12 +74,7 @@ aliases:
   - lberk
   - matzew
   eventing-rabbitmq-approvers:
-  - andrew-su
-  - chunyilyu
-  - gabo1208
-  - joeeltgroth
-  - salaboy
-  - xtreme-sameer-vohra
+  - tcnghia
   eventing-redis-approvers:
   - aavarghese
   - lionelvillard

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -1018,12 +1018,7 @@ orgs:
         repos:
           eventing-rabbitmq: write
         members:
-        - andrew-su
-        - chunyilyu
-        - gabo1208
-        - joeeltgroth
-        - salaboy
-        - xtreme-sameer-vohra
+        - tcnghia
       eventing-redis Approvers:
         description: Approver group for eventing-redis - to be used in CODEOWNERS file
         privacy: closed

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -1019,6 +1019,7 @@ orgs:
           eventing-rabbitmq: write
         members:
         - tcnghia
+        - gabo1208
       eventing-redis Approvers:
         description: Approver group for eventing-redis - to be used in CODEOWNERS file
         privacy: closed


### PR DESCRIPTION
As a results of some restructuring due to the VMware/Broadcom acquisition we're unable to maintain this integration.

I've chatted with Chainguard and they use this integration in production so I'm transitioning approver responsibilities to them.

If anyone else would also like approver status I'd imagine the help would be welcome.