### PR TITLE
Use slack ids rather than handles for toc review notifications

### DIFF
--- a/mechanics/TOC-REVIEW.schedule
+++ b/mechanics/TOC-REVIEW.schedule
@@ -1,15 +1,15 @@
 # Date in %F format ie: YYYY-DD-MM | Working Group | Members to be notified
 2024-02-14 | Security WG | @Evan Anderson @David Hadas
 2024-02-28 | Productivity WG | @Krsna Mahapatra @Mahamed Ali
-2024-03-13 | UX WG | @cali0707 @leo6leo @mmejia02 @zainabhusain227
-2024-03-27 | Client WG | @dsimansk @Navid Shaikh @Roland Huss
-2024-04-10 | Serving API WG | @dprotaso
-2024-04-24 | Operations WG | @houshengbo
-2024-05-08 | Functions WG | @lkingland @salaboy
-2024-05-22 | Eventing WG | @pierDipi
-2024-06-05 | Security WG | @Evan Anderson @David Hadas
-2024-06-19 | Productivity WG | @Krsna Mahapatra @Mahamed Ali
-2024-07-03 | UX WG | @cali0707 @leo6leo @mmejia02 @zainabhusain227
-2024-07-17 | Client WG | @dsimansk @Navid Shaikh @Roland Huss
-2024-07-31 | Serving API WG | @dprotaso
-2024-08-14 | Operations WG | @houshengbo
+2024-03-13 | UX WG | <@U05999D66LD> <@U059QSFTWQH> <@U05KBM5KXL2> <@U05MMMAFX1D>
+2024-03-27 | Client WG | <@U04M6CBMLD7> <@U015VV08WP2>
+2024-04-10 | Serving API WG | <@ULXQUF6RK>
+2024-04-24 | Operations WG | <@U04ME6E2ZSL>
+2024-05-08 | Functions WG | <@UM847GSTU> <@U021DUWTHK6>
+2024-05-22 | Eventing WG | <@U018JAXEV9V>
+2024-06-05 | Security WG | <@USE6QPTEG> <@U042ELWDYLQ>
+2024-06-19 | Productivity WG | <@U01EUH1TFRR> <@U04M85SQZ97>
+2024-07-03 | UX WG | <@U05999D66LD> <@U059QSFTWQH> <@U05KBM5KXL2> <@U05MMMAFX1D>
+2024-07-17 | Client WG | <@U04M6CBMLD7> <@U015VV08WP2>
+2024-07-31 | Serving API WG | <@ULXQUF6RK>
+2024-08-14 | Operations WG | <@U04ME6E2ZSL>


### PR DESCRIPTION
# Changes

tldr: Updates TOC review notifications to use Slack ID rather than Handle.

We have a bot that sends slack notifications to WG leads for the TOC review presentations: https://github.com/knative/community/blob/main/.github/workflows/toc-review-reminder.yaml

However, in order for individuals to get notified via Slack, we need to use their Slack ID rather than their handle (as described in [this comment](https://github.com/rtCamp/action-slack-notify/issues/93#issuecomment-854547992)). So this PR makes that update.

