### PR TITLE
New private Google group for UX WG leads

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -23,4 +23,7 @@ restrictions:
       - "^wg-leads@knative.team$"
       - "^calendar-maintainers@knative.team$"
       - "^admins@knative.dev$"
+  - path: "wg-ux/groups.yaml"
+    allowedGroups:
+      - "^ux@knative.team$"
   - path: "**/*" # prevent any other file from containing anything

--- a/groups/wg-ux/OWNERS
+++ b/groups/wg-ux/OWNERS
@@ -1,0 +1,6 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- ux-writers
+reviewers:
+- ux-writers

--- a/groups/wg-ux/groups.yaml
+++ b/groups/wg-ux/groups.yaml
@@ -1,0 +1,17 @@
+# UX WG
+groups:
+  - email-id: ux@knative.team
+    name: ux
+    description: |-
+      UX WG email
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - zainabhusain@ocadu.ca
+      - mariana.mejia@ocadu.ca
+      - leoli@redhat.com
+      - cmurray@redhat.com
+    members:
+      - aliok@redhat.com
+


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- I want to create a new mail alias for the UX WG leads. They're gonna sign up to some systems (Figma, etc) and they want to share their username and password for consolidation.
- So, obviously, this group needs to be private.



