### PR TITLE
Add Norris to steering / GitHub Org

### DIFF
--- a/groups/committee-steering/groups.yaml
+++ b/groups/committee-steering/groups.yaml
@@ -9,8 +9,8 @@ groups:
     owners:
       - aliok@redhat.com
       - evan.k.anderson@gmail.com
-      - puerco@chainguard.dev
       - naina.sng@gmail.com
+      - Norris.SamOsarenkhoe@sva.de
       - salaboy@gmail.com
 
   - email-id: elections@knative.team

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -18,8 +18,8 @@ orgs:
     - evankanderson
     - knative-prow-robot
     - nainaz
+    - nrrso
     - psschwei
-    - puerco
     - salaboy
     - thelinuxfoundation
     - krsna-m
@@ -107,6 +107,7 @@ orgs:
     - pierDipi
     - pmorie
     - pradnyavmw
+    - puerco
     - pymhq
     - RamyChaabane
     - ReToCode

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -17,8 +17,8 @@ orgs:
     - evankanderson
     - knative-prow-robot
     - nainaz
+    - nrrso
     - psschwei
-    - puerco
     - salaboy
     - thelinuxfoundation
     - krsna-m
@@ -108,6 +108,7 @@ orgs:
     - pmbanugo
     - pmorie
     - pradnyavmw
+    - puerco
     - pymhq
     - quentin-cha
     - ReToCode


### PR DESCRIPTION
# Changes

- Add Norris as the new end-user seat representative to the GitHub org and to steering lists
- Move puerco to Knative membership (Thanks!)
- Note that we do not yet add @nrrso to GitHub groups within the org because he'll need to accept the org invite first to avoid errors.

<!--
/kind cleanup

-->
