### PR TITLE
Add nrrso to knative orgs

### DIFF
--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -102,6 +102,7 @@ orgs:
     - navidshaikh
     - norbjd
     - norman465
+    - nrrso
     - odacremolbap
     - omerbensaadon
     - pierDipi

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -102,6 +102,7 @@ orgs:
     - nader-ziada
     - navidshaikh
     - norman465
+    - nrrso
     - odacremolbap
     - omerbensaadon
     - pierDipi


### PR DESCRIPTION
@nrrso was added as a SC member in #1521. 
We missed to add him to the knative orgs, which leads to `invalid-owners` errors on the `Update community files` PRs (e.g. https://github.com/knative/eventing/pull/7787#issuecomment-1996226538).

This PR adds @nrrso as a member to the knative and knative-extensions orgs.

/assign @aliok 