### PR TITLE
Add Iliia Khaprov @ RabbitMQ as Eventing RabbitMQ maintainer

### DIFF
--- a/peribolos/knative-extensions-OWNERS_ALIASES
+++ b/peribolos/knative-extensions-OWNERS_ALIASES
@@ -82,6 +82,7 @@ aliases:
   - matzew
   eventing-rabbitmq-approvers:
   - gabo1208
+  - ikavgo
   - tcnghia
   eventing-redis-approvers:
   - aavarghese

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -63,6 +63,7 @@ orgs:
     - hh
     - hhk7734
     - houshengbo
+    - ikavgo
     - itsmurugappan
     - izabelacg
     - jcrossley3
@@ -1024,6 +1025,7 @@ orgs:
         repos:
           eventing-rabbitmq: write
         members:
+        - ikavgo
         - tcnghia
         - gabo1208
       eventing-redis Approvers:

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -62,6 +62,7 @@ orgs:
     - hh
     - hhk7734
     - houshengbo
+    - ikavgo
     - ImJasonH
     - itsmurugappan
     - izabelacg


### PR DESCRIPTION

# Changes

/kind enhancement


**Release Note**

```release-note
Iliia Khaprov @ RabbitMQ added back as Knative Eventing RabbitMQ maintainer
```

cc @dprotaso 