### PR TITLE
Revoke release leads permissions since 1.14 is out

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -52,17 +52,12 @@ aliases:
   - lkingland
   - salaboy
   knative-admin:
-  - Cali0707
-  - Leo6Leo
-  - ReToCode
   - aliok
   - cardil
-  - creydr
   - davidhadas
   - dprotaso
   - dsimansk
   - evankanderson
-  - izabelacg
   - knative-automation
   - knative-prow-releaser-robot
   - knative-prow-robot
@@ -70,20 +65,10 @@ aliases:
   - knative-test-reporter-robot
   - krsna-m
   - nainaz
-  - pierDipi
   - psschwei
   - salaboy
-  - skonto
   - upodroid
-  knative-release-leads:
-  - Cali0707
-  - Leo6Leo
-  - ReToCode
-  - creydr
-  - dsimansk
-  - izabelacg
-  - pierDipi
-  - skonto
+  knative-release-leads: []
   knative-robots:
   - knative-automation
   - knative-prow-releaser-robot

--- a/peribolos/knative-extensions-OWNERS_ALIASES
+++ b/peribolos/knative-extensions-OWNERS_ALIASES
@@ -155,17 +155,12 @@ aliases:
   - christophd
   - rhuss
   knative-admin:
-  - Cali0707
-  - Leo6Leo
-  - ReToCode
   - aliok
   - cardil
-  - creydr
   - davidhadas
   - dprotaso
   - dsimansk
   - evankanderson
-  - izabelacg
   - knative-automation
   - knative-prow-releaser-robot
   - knative-prow-robot
@@ -173,20 +168,10 @@ aliases:
   - knative-test-reporter-robot
   - krsna-m
   - nainaz
-  - pierDipi
   - psschwei
   - salaboy
-  - skonto
   - upodroid
-  knative-release-leads:
-  - Cali0707
-  - Leo6Leo
-  - ReToCode
-  - creydr
-  - dsimansk
-  - izabelacg
-  - pierDipi
-  - skonto
+  knative-release-leads: []
   knative-robots:
   - knative-automation
   - knative-prow-releaser-robot

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -755,17 +755,9 @@ orgs:
           Knative Release Leads:
             privacy: closed
             description: Active members of the Knative Release Leads rotation.
-            maintainers:
-            - dsimansk
-            - skonto
-            - pierDipi
-            - creydr
-            - ReToCode
-            - Cali0707
-            - Leo6Leo
-            - izabelacg
+            maintainers: []
           Productivity Leads:
-            #Using the same team name as below `Productivity WG Leads` puts periboilos in a weird state.
+            #Using the same team name as below `Productivity WG Leads` puts peribolos in a weird state.
             privacy: closed
             description: Members of the Productivity WG Leads.
             maintainers:

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -530,17 +530,9 @@ orgs:
           Knative Release Leads:
             privacy: closed
             description: Active members of the Knative Release Leads rotation.
-            maintainers:
-            - dsimansk
-            - skonto
-            - pierDipi
-            - creydr
-            - ReToCode
-            - Cali0707
-            - Leo6Leo
-            - izabelacg
+            maintainers: []
           Productivity Leads:
-            #Using the same team name as below `Productivity WG Leads` puts periboilos in a weird state.
+            #Using the same team name as below `Productivity WG Leads` puts peribolos in a weird state.
             privacy: closed
             description: Members of the Productivity WG Leads.
             maintainers:


### PR DESCRIPTION
# Changes

- Revoke release leads permissions since 1.14 is out
