### PR TITLE
Revoke Release Leads role for completed release

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -49,9 +49,6 @@ aliases:
   - lkingland
   - salaboy
   knative-admin:
-  - Cali0707
-  - Leo6Leo
-  - ReToCode
   - aliok
   - cardil
   - davidhadas
@@ -66,14 +63,8 @@ aliases:
   - nainaz
   - psschwei
   - salaboy
-  - skonto
   - upodroid
-  knative-release-leads:
-  - Cali0707
-  - Leo6Leo
-  - ReToCode
-  - dsimansk
-  - skonto
+  knative-release-leads: []
   knative-robots:
   - knative-automation
   - knative-prow-releaser-robot

--- a/peribolos/knative-extensions-OWNERS_ALIASES
+++ b/peribolos/knative-extensions-OWNERS_ALIASES
@@ -149,9 +149,6 @@ aliases:
   - christophd
   - rhuss
   knative-admin:
-  - Cali0707
-  - Leo6Leo
-  - ReToCode
   - aliok
   - cardil
   - davidhadas
@@ -166,14 +163,8 @@ aliases:
   - nainaz
   - psschwei
   - salaboy
-  - skonto
   - upodroid
-  knative-release-leads:
-  - Cali0707
-  - Leo6Leo
-  - ReToCode
-  - dsimansk
-  - skonto
+  knative-release-leads: []
   knative-robots:
   - knative-automation
   - knative-prow-releaser-robot

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -755,12 +755,7 @@ orgs:
           Knative Release Leads:
             privacy: closed
             description: Active members of the Knative Release Leads rotation.
-            maintainers:
-            - ReToCode
-            - skonto
-            - Cali0707
-            - Leo6Leo
-            - dsimansk 
+            maintainers: []
           Productivity Leads:
             #Using the same team name as below `Productivity WG Leads` puts peribolos in a weird state.
             privacy: closed

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -528,12 +528,7 @@ orgs:
           Knative Release Leads:
             privacy: closed
             description: Active members of the Knative Release Leads rotation.
-            maintainers:
-            - ReToCode
-            - skonto
-            - Cali0707
-            - Leo6Leo
-            - dsimansk 
+            maintainers: []
           Productivity Leads:
             #Using the same team name as below `Productivity WG Leads` puts peribolos in a weird state.
             privacy: closed


### PR DESCRIPTION
Per final item on release checklist, revoke permissions.  

Changes 

- Revoke Release Leads role for completed release


/cc @knative/knative-release-leads 
/cc @knative/technical-oversight-committee 