### PR TITLE
Remove 'shinigambit' user from peribolos configs

### DIFF
--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -117,7 +117,6 @@ orgs:
     - sebgoa
     - senthilnathan
     - Shashankft9
-    - shinigambit
     - ShravaniAK
     - skonto
     - smoser-ibm

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -122,7 +122,6 @@ orgs:
     - sebgoa
     - senthilnathan
     - Shashankft9
-    - shinigambit
     - ShravaniAK
     - skonto
     - smoser-ibm


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- The user profile doesn't exist anymore: https://github.com/shinigambit

It seems like an instance of old Prow issue: https://github.com/kubernetes/test-infra/issues/17671

There's a OK run for main org and failed for extensions, but...

https://prow.knative.dev/?job=ci-knative-peribolos
https://prow.knative.dev/?job=ci-knative-extensions-peribolos

/cc @upodroid @cardil 


