### PR TITLE
Remove 'thisisnotapril' user from knative-extensions config

### DIFF
--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -128,7 +128,6 @@ orgs:
     - sutaakar
     - tardieu
     - tcnghia
-    - thisisnotapril
     - tzununbekov
     - vagababov
     - vaibhavjainwiz


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- One more instance of previously described issue with #1615 

That's probably even more strange because @thisisnotapril profile definitely exists, and we got her in Knative org. There might a problem that other invite was never accepted.


/cc @upodroid @cardil 
