### PR TITLE
Update release leads for Knative 1.16

### DIFF
--- a/.github/workflows/peribolos-schema-validate.yaml
+++ b/.github/workflows/peribolos-schema-validate.yaml
@@ -25,11 +25,11 @@ jobs:
     name: Check peribolos schema.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         lfs: true
-    - run: pip install strictyaml
+    - run: pip install strictyaml --break-system-packages
     - name: Validate knative.yaml
       run: python3 peribolos/validate-schema.py peribolos/knative.yaml
     - name: Validate knative-extensions.yaml

--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -62,9 +62,14 @@ aliases:
   - knative-test-reporter-robot
   - nainaz
   - psschwei
+  - retocode
   - salaboy
+  - skonto
   - upodroid
-  knative-release-leads: []
+  knative-release-leads:
+  - dsimansk
+  - retocode
+  - skonto
   knative-robots:
   - knative-automation
   - knative-prow-releaser-robot

--- a/peribolos/knative-extensions-OWNERS_ALIASES
+++ b/peribolos/knative-extensions-OWNERS_ALIASES
@@ -158,9 +158,14 @@ aliases:
   - knative-test-reporter-robot
   - nainaz
   - psschwei
+  - retocode
   - salaboy
+  - skonto
   - upodroid
-  knative-release-leads: []
+  knative-release-leads:
+  - dsimansk
+  - retocode
+  - skonto
   knative-robots:
   - knative-automation
   - knative-prow-releaser-robot

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -764,7 +764,10 @@ orgs:
           Knative Release Leads:
             privacy: closed
             description: Active members of the Knative Release Leads rotation.
-            maintainers: []
+            maintainers:
+            - dsimansk
+            - retocode
+            - skonto
           Productivity Leads:
             #Using the same team name as below `Productivity WG Leads` puts peribolos in a weird state.
             privacy: closed

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -527,7 +527,10 @@ orgs:
           Knative Release Leads:
             privacy: closed
             description: Active members of the Knative Release Leads rotation.
-            maintainers: []
+            maintainers:
+            - dsimansk
+            - retocode
+            - skonto
           Productivity Leads:
             #Using the same team name as below `Productivity WG Leads` puts peribolos in a weird state.
             privacy: closed


### PR DESCRIPTION
Related to: https://github.com/knative/release/pull/330

/cc @skonto @ReToCode 
/cc @knative/technical-oversight-committee 