### PR TITLE
Archive eventing-kogito repository

### DIFF
--- a/peribolos/knative-extensions-OWNERS_ALIASES
+++ b/peribolos/knative-extensions-OWNERS_ALIASES
@@ -58,8 +58,6 @@ aliases:
   - Leo6Leo
   - cali0707
   eventing-kafka-writers: []
-  eventing-kogito-approvers:
-  - ricardozanini
   eventing-natss-approvers:
   - astelmashenko
   - dan-j

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -301,6 +301,7 @@ orgs:
         has_wiki: false
         squash_merge_commit_title: PR_TITLE
         squash_merge_commit_message: COMMIT_MESSAGES
+        archived: true
       eventing-kafka-broker:
         allow_merge_commit: false
         allow_rebase_merge: false
@@ -982,14 +983,6 @@ orgs:
         - lberk
         - matzew
         - pierDipi
-
-      eventing-kogito Approvers:
-        description: Approver group for eventing-kogito - to be used in CODEOWNERS file
-        privacy: closed
-        repos:
-          eventing-kogito: write
-        members:
-        - ricardozanini
 
       eventing-kafka-broker Approvers:
         description: Approver group for eventing-kafka-broker - to be used in CODEOWNERS file


### PR DESCRIPTION
Per https://github.com/knative-extensions/eventing-kogito/pull/419

Note: I haven't removed Eventing write access as fallback option.

/cc @ricardozanini @pierDipi 
/cc @knative/productivity-leads 