### PR TITLE
Add KSC members to peribolos toc alias temporarily

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -125,7 +125,15 @@ aliases:
   - nainaz
   - psschwei
   - salaboy
-  technical-oversight-committee: []
+  technical-oversight-committee:
+  - aliok
+  - davidhadas
+  - dprotaso
+  - dsimansk
+  - evankanderson
+  - nainaz
+  - psschwei
+  - salaboy
   ux-wg-leads:
   - cali0707
   - leo6leo

--- a/peribolos/knative-extensions-OWNERS_ALIASES
+++ b/peribolos/knative-extensions-OWNERS_ALIASES
@@ -230,7 +230,15 @@ aliases:
   - nainaz
   - psschwei
   - salaboy
-  technical-oversight-committee: []
+  technical-oversight-committee:
+  - aliok
+  - davidhadas
+  - dprotaso
+  - dsimansk
+  - evankanderson
+  - nainaz
+  - psschwei
+  - salaboy
   ux-wg-leads:
   - cali0707
   - leo6leo

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -768,7 +768,15 @@ orgs:
             privacy: closed
           Technical Oversight Committee:
             description: Members of the Knative Technical Oversight Committee (TOC)
-            maintainers: []
+            maintainers:
+            - aliok
+            - evankanderson
+            - nainaz
+            - salaboy
+            - davidhadas
+            - dprotaso
+            - dsimansk
+            - psschwei
             privacy: closed
           Knative Release Leads:
             privacy: closed

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -521,7 +521,15 @@ orgs:
             privacy: closed
           Technical Oversight Committee:
             description: Members of the Knative Technical Oversight Committee (TOC)
-            maintainers: []
+            maintainers:
+            - aliok
+            - evankanderson
+            - nainaz
+            - salaboy
+            - davidhadas
+            - dprotaso
+            - dsimansk
+            - psschwei
             privacy: closed
           Knative Release Leads:
             privacy: closed


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Add KSC members to peribolos toc alias temporarily


Addressing an issue with majority of repositories not referencing steering alias in `OWNERS` file. Gradually, WGs should be able to update `OWNERS` to include `steering-commitee` and then we can sunset the other alias. 

/cc @dprotaso 