### PR TITLE
Remove owners field in 2024 SC election config

### DIFF
--- a/elections/2024-SC/election.yaml
+++ b/elections/2024-SC/election.yaml
@@ -7,7 +7,6 @@ allow_no_opinion: True
 delete_after: True
 show_candidate_fields:
   - affiliation
-  - owners
 election_officers:
   - geekygirldawn
   - jberkus


### PR DESCRIPTION
Copy & past issue.
Owners field is not needed in election config, as it does not exist in candidate template

/cc @jberkus 