### PR TITLE
fix peribolos and google groups config

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -59,4 +59,8 @@ groups:
       AllowExternalMembers: "false"
       WhoCanPostMessage: "ANYONE_CAN_POST"
     members:
-      - steering@knative.team
+      - aliok@redhat.com
+      - developer@nrrso.com
+      - evan.k.anderson@gmail.com
+      - dprotaso@gmail.com
+      - mwessend@redhat.com

--- a/groups/wg-productivity/groups.yaml
+++ b/groups/wg-productivity/groups.yaml
@@ -39,7 +39,6 @@ groups:
     members:
       - k8s-infra-rbac-prow@knative.dev
       - k8s-infra-rbac-release@knative.dev
-      - k8s-infra-rbac-perf-tests@knative.dev
 
   # GKE RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on a cluster

--- a/groups/wg-productivity/groups.yaml
+++ b/groups/wg-productivity/groups.yaml
@@ -64,20 +64,9 @@ groups:
       ReconcileMembers: "true"
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
     members:
-      - evana@vmware.com
       - evan.k.anderson@gmail.com
       - paul@paulschweigert.com
       - paulschw@us.ibm.com
-
-  - email-id: k8s-infra-rbac-perf-tests@knative.dev
-    name: k8s-infra-rbac-perf-tests
-    description: |-
-      Grants access to the shared community cluster perf-tests namespace
-    settings:
-      ReconcileMembers: "true"
-      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
-    members:
-      - retocode@gmail.com
 
   ##
   ### Productivity WG related mailing lists
@@ -92,7 +81,7 @@ groups:
       ReconcileMembers: "true"
       WhoCanPostMessage: "ANYONE_CAN_POST"
     owners:
-      - evana@vmware.com
+      - evan.k.anderson@gmail.com
       - evankanderson@knative.team
       - dprotaso@gmail.com
     managers:

--- a/groups/wg-security/groups.yaml
+++ b/groups/wg-security/groups.yaml
@@ -9,6 +9,5 @@ groups:
       ReconcileMembers: "true"
     owners:
       - evan.k.anderson@gmail.com
-      - evana@vmware.com
       - evankanderson@knative.team
       - david.hadas@gmail.com

--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -49,7 +49,6 @@ aliases:
   knative-admin:
   - aliok
   - cardil
-  - davidhadas
   - dprotaso
   - dsimansk
   - evankanderson
@@ -58,9 +57,8 @@ aliases:
   - knative-prow-robot
   - knative-prow-updater-robot
   - knative-test-reporter-robot
-  - nainaz
-  - psschwei
-  - salaboy
+  - matzew
+  - nrrso
   - skonto
   - upodroid
   knative-release-leads:
@@ -114,22 +112,10 @@ aliases:
   - skonto
   steering-committee:
   - aliok
-  - davidhadas
   - dprotaso
-  - dsimansk
   - evankanderson
-  - nainaz
-  - psschwei
-  - salaboy
-  technical-oversight-committee:
-  - aliok
-  - davidhadas
-  - dprotaso
-  - dsimansk
-  - evankanderson
-  - nainaz
-  - psschwei
-  - salaboy
+  - matzew
+  - nrrso
   ux-wg-leads:
   - cali0707
   - leo6leo

--- a/peribolos/knative-extensions-OWNERS_ALIASES
+++ b/peribolos/knative-extensions-OWNERS_ALIASES
@@ -142,7 +142,6 @@ aliases:
   knative-admin:
   - aliok
   - cardil
-  - davidhadas
   - dprotaso
   - dsimansk
   - evankanderson
@@ -151,9 +150,8 @@ aliases:
   - knative-prow-robot
   - knative-prow-updater-robot
   - knative-test-reporter-robot
-  - nainaz
-  - psschwei
-  - salaboy
+  - matzew
+  - nrrso
   - skonto
   - upodroid
   knative-release-leads:
@@ -219,22 +217,10 @@ aliases:
   - skonto
   steering-committee:
   - aliok
-  - davidhadas
   - dprotaso
-  - dsimansk
   - evankanderson
-  - nainaz
-  - psschwei
-  - salaboy
-  technical-oversight-committee:
-  - aliok
-  - davidhadas
-  - dprotaso
-  - dsimansk
-  - evankanderson
-  - nainaz
-  - psschwei
-  - salaboy
+  - matzew
+  - nrrso
   ux-wg-leads:
   - cali0707
   - leo6leo

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -18,6 +18,7 @@ orgs:
     # cncf
     - caniszczyk
     - cncf-ci
+    - linuxfoundation
     # productivity
     - upodroid
     - knative-prow-robot

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -16,7 +16,6 @@ orgs:
     - matzew
     - nrrso
     # cncf
-    - thelinuxfoundation
     - caniszczyk
     - cncf-ci
     # productivity
@@ -67,10 +66,8 @@ orgs:
     - itsmurugappan
     - izabelacg
     - jcrossley3
-    - jkjell
     - joeeltgroth
     - jrangelramos
-    - JRBANCEL
     - jsanin-vmw
     - julz
     - jwcesign
@@ -760,26 +757,10 @@ orgs:
             description: ""
             maintainers:
             - aliok
-            - evankanderson
-            - nainaz
-            - salaboy
-            - davidhadas
             - dprotaso
-            - dsimansk
-            - psschwei
-            privacy: closed
-          Technical Oversight Committee:
-            description: Members of the Knative Technical Oversight Committee (TOC)
-            maintainers:
-            - aliok
             - evankanderson
-            - nainaz
-            - salaboy
-            - davidhadas
-            - dprotaso
-            - dsimansk
-            - psschwei
-            privacy: closed
+            - matzew
+            - nrrso
           Knative Release Leads:
             privacy: closed
             description: Active members of the Knative Release Leads rotation.

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -761,6 +761,7 @@ orgs:
             - evankanderson
             - matzew
             - nrrso
+            privacy: closed
           Knative Release Leads:
             privacy: closed
             description: Active members of the Knative Release Leads rotation.

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -17,6 +17,7 @@ orgs:
     # cncf
     - caniszczyk
     - cncf-ci
+    - linuxfoundation
     # productivity wg lead
     - upodroid
     - knative-prow-robot

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -15,7 +15,6 @@ orgs:
     - matzew
     - nrrso
     # cncf
-    - thelinuxfoundation
     - caniszczyk
     - cncf-ci
     # productivity wg lead
@@ -69,9 +68,7 @@ orgs:
     - izabelacg
     - jberkus
     - jcrossley3
-    - jkjell
     - jrangelramos
-    - JRBANCEL
     - jsanin-vmw
     - julz
     - jwcesign
@@ -512,25 +509,10 @@ orgs:
             description: Knative Steering Committee
             maintainers:
             - aliok
-            - evankanderson
-            - nainaz
-            - salaboy
-            - davidhadas
             - dprotaso
-            - dsimansk
-            - psschwei
-            privacy: closed
-          Technical Oversight Committee:
-            description: Members of the Knative Technical Oversight Committee (TOC)
-            maintainers:
-            - aliok
             - evankanderson
-            - nainaz
-            - salaboy
-            - davidhadas
-            - dprotaso
-            - dsimansk
-            - psschwei
+            - matzew
+            - nrrso
             privacy: closed
           Knative Release Leads:
             privacy: closed


### PR DESCRIPTION
1. update steering teams and try to fix post update job - drop jkjell & jr from memberlist (there are warnings about those)

error message in peribolos the post submit job

`
{"client":"github","component":"peribolos","level":"info","msg":"UpdateOrgMembership(knative, jkjell, false)","severity":"info","time":"2025-01-22T20:41:01Z"}
{"component":"peribolos","error":"status code 422 not one of [200], body: {\"message\":\"The request could not be processed.\",\"documentation_url\":\"https://docs.github.com/rest/orgs/members#set-organization-membership-for-a-user\",\"status\":\"422\"}","level":"warning","msg":"UpdateOrgMembership(knative, jkjell, false) failed","severity":"warning","time":"2025-01-22T20:41:01Z"}
{"component":"peribolos","level":"info","msg":"Waiting for jrbancel to accept invitation to knative","severity":"info","time":"2025-01-22T20:41:01Z"}
{"component":"peribolos","level":"fatal","msg":"Configuration failed: failed to configure knative members: status code 422 not one of [200], body: {\"message\":\"The request could not be processed.\",\"documentation_url\":\"https://docs.github.com/rest/orgs/members#set-organization-membership-for-a-user\",\"status\":\"422\"}","severity":"fatal","time":"2025-01-22T20:41:01Z"}
`