### PR TITLE
adjust memberships

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -11,7 +11,11 @@ groups:
       MessageModerationLevel: "MODERATE_NON_MEMBERS"
       ReconcileMembers: "true"
     owners:
-    - steering@knative.team
+    - aliok@redhat.com
+    - developer@nrrso.com
+    - evan.k.anderson@gmail.com
+    - dprotaso@gmail.com
+    - mwessend@redhat.com
     members:
       # Serving
       # - dprotaso@gmail.com: already in the owners list

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -18,7 +18,7 @@ orgs:
     # cncf
     - caniszczyk
     - cncf-ci
-    - linuxfoundation
+    - thelinuxfoundation
     # productivity
     - upodroid
     - knative-prow-robot

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -17,7 +17,7 @@ orgs:
     # cncf
     - caniszczyk
     - cncf-ci
-    - linuxfoundation
+    - thelinuxfoundation
     # productivity wg lead
     - upodroid
     - knative-prow-robot


### PR DESCRIPTION
Post submit jobs failed for https://github.com/knative/community/pull/1659

groups - https://prow.knative.dev/view/gs/knative-prow/logs/post-knativeteam-groups/1883895909339631616 
peribolos - https://prow.knative.dev/view/gs/knative-prow/logs/post-knative-peribolos/1883895909410934784

Fixes:
- add the right user account 'thelinuxfoundation'
- can't make a group ('steering') an owner of a group ('wg-leads')



