### PR TITLE
Adding Chris Suszynski to Productivity GCP admins

### DIFF
--- a/groups/groups_test.go
+++ b/groups/groups_test.go
@@ -284,6 +284,7 @@ func TestHardcodedGroupsForParanoia(t *testing.T) {
 			"dprotaso@gmail.com",
 			"jeffrey@cncf.io",
 			"dkrook@linuxfoundation.org",
+			"ksuszyns@redhat.com",
 			"mario@kubermatic.com",
 		},
 	}

--- a/groups/wg-productivity/groups.yaml
+++ b/groups/wg-productivity/groups.yaml
@@ -21,6 +21,7 @@ groups:
     members:
       - cy@knative.team
       - cy@borg.dev # Mahamed Ali
+      - ksuszyns@redhat.com # Chris Suszynski
       - dprotaso@gmail.com # Dave Protasowski
       - hh@knative.team
       - hh@cncf.io
@@ -54,6 +55,7 @@ groups:
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
     members:
       - cy@borg.dev # Mahamed Ali
+      - ksuszyns@redhat.com # Chris Suszynski
 
   - email-id: k8s-infra-rbac-release@knative.dev
     name: k8s-infra-rbac-release
@@ -66,6 +68,7 @@ groups:
       - evan.k.anderson@gmail.com
       - paul@paulschweigert.com
       - paulschw@us.ibm.com
+      - ksuszyns@redhat.com # Chris Suszynski
 
   ##
   ### Productivity WG related mailing lists
@@ -85,3 +88,4 @@ groups:
       - dprotaso@gmail.com
     managers:
        - cy@borg.dev # Mahamed Ali
+       - ksuszyns@redhat.com # Chris Suszynski


### PR DESCRIPTION
# Changes

- :broom: Adding Chris Suszynski to Productivity GCP admins

/kind cleanup

As [discussed on Productivity WG on Mar 12, 2025](https://docs.google.com/document/d/1aPRwYGD4XscRIqlBzbNsSB886PJ0G-vZYUAAUjoydko/edit?tab=t.0), I'm adding myself to the GCP admins group, to be able to operate terraform code, and troubleshoot issues on GCP.