### PR TITLE
Add Christoph (@creydr) as Eventing WG lead

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -23,6 +23,7 @@ aliases:
   - cali0707
   - creydr
   eventing-wg-leads:
+  - creydr
   - pierDipi
   eventing-writers:
   - Leo6Leo

--- a/peribolos/knative-extensions-OWNERS_ALIASES
+++ b/peribolos/knative-extensions-OWNERS_ALIASES
@@ -74,6 +74,7 @@ aliases:
   - cali0707
   - creydr
   eventing-wg-leads:
+  - creydr
   - pierDipi
   eventing-writers:
   - Leo6Leo

--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -647,6 +647,7 @@ orgs:
             description: The Working Group leads for Eventing
             members:
             - pierDipi
+            - creydr
             privacy: closed
         members:
         - aliok

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -428,6 +428,7 @@ orgs:
             description: The Working Group leads for Eventing
             members:
             - pierDipi
+            - creydr
             privacy: closed
         members:
         - aliok


### PR DESCRIPTION
Christoph has been Eventing approver for almost 2 years
(since Aug 7, 2023), he is leading the Eventing Security story,
has been the main Eventing release lead for the last year
releases, advocate for Eventing Discovery [3], and a co-mentor
for the GSoC mentorship program [4].

Christoph has over 110 mid-sized+ reviews [1], and over 130 merged
PRs [2] just in core Eventing.

[1] https://github.com/knative/eventing/pulls?q=is%3Apr+is%3Amerged+reviewed-by%3Acreydr+-label%3Asize%2FS+-label%3Asize%2FXS+-author%3Acreydr+is%3Aclosed+-mentions%3Aknative-automation+
[2] https://github.com/knative/eventing/pulls?q=is%3Apr+is%3Amerged+author%3Acreydr+is%3Aclosed
[3] https://youtu.be/z-SuVsvxvm4?si=6iw9trKW6bGus6zi
[4] https://gist.github.com/debasishbsws/5b32514a96c3c516d12e40b26ae019ea

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>