### PR TITLE
Clarify policies for removal of steering committee members

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,22 @@
+---
+title: Knative Governance Model
+linkTitle: Governance
+weight: 20
+type: "docs"
+aliases:
+  - /contributing/governance
+---
+
+Knative has used a number of different governance models in the past. The
+_current_ governance of the Knative project is managed by the [Knative Steering
+Committee](./STEERING-COMMITTEE.md), which delegates much of the technical work
+to different [working groups](./working-groups/WORKING-GROUPS.md), which are
+focused on specific components of Knative.
+
+All participants in the Knative project are contributors; contributors who
+reach a minimum level of interactions ([currently 25 interactions in 12
+months](./STEERING-COMMITTEE.md#eligibility-to-vote)) is eligible to
+participate in [steering committee
+elections](./STEERING-COMMITTEE.md#election-procedure).  Other roles in the
+project are awarded based on participation, see [ROLES.md](./ROLES.md) for
+details on the permissions and requirements for other roles.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,17 @@
+---
+title: Knative Maintainers
+linkTitle: Maintainers
+weight: 80
+type: "docs"
+---
+
+# Maintainers
+
+Knative [has a number of different roles](./ROLES.md) which have varying
+permissions within the Knative components.  For the purposes of CNCF
+maintainership (e.g. service desk access, Knative calendar acesss, KubeCon
+maintainer talk eligibility and project pavillion access), Knative maintainers
+are defined as the following:
+
+* [Working Group Leads](./ROLES.md#working-group-lead)
+* [Steering Committee Member](./STEERING-COMMITTEE.md#committee-members)

--- a/ROLES.md
+++ b/ROLES.md
@@ -1,7 +1,7 @@
 This document describes the set of roles individuals might have within the
 Knative community, the requirements of each role, and the privileges that each
 role grants. Community members generally start at the first levels of the
-"ladder" and advance up it as their involvement in the project grows.  Our
+"ladder" and advance up it as their involvement in the project grows. Our
 project members are happy to help you advance along the contributor ladder.
 
 - [Role Summary](#role-summary)
@@ -62,6 +62,7 @@ have defined responsibilities.
 A Contributor contributes directly to the project and adds value to it.
 Contributions need not be code. People at the Contributor level may be new
 contributors, or they may only contribute occasionally.
+
 ### Requirements
 
 Contributors should be familiar with the project and its processes, and should
@@ -101,9 +102,10 @@ this is not a requirement.
 ### Requirements
 
 - Member of the Knative GitHub org
+
   - Create a PR adding yourself as a Member to
-[knative.yaml](../main/peribolos/knative.yaml) and/or to
-[knative-extensions.yaml](../main/peribolos/knative-extensions.yaml)
+    [knative.yaml](../main/peribolos/knative.yaml) and/or to
+    [knative-extensions.yaml](../main/peribolos/knative-extensions.yaml)
   - After the PR is merged you will receive an invite that you must accept to become a Member
   - If you would like to work towards becoming an Approver, open a second PR and add yourself as a `reviewer` on the repositories to which you will be contributing.
 
@@ -169,7 +171,6 @@ approver in an OWNERS file:
 The following apply to the part of the repository for which one would be an
 approver in an OWNERS file:
 
-
 - Demonstrate sound judgment
 
 * Responsible for project quality control via [reviews](./REVIEWING.md)
@@ -185,10 +186,8 @@ approver in an OWNERS file:
 * Approve contributions for acceptance
 
 Approvers are also expected to participate in community contact rotations
-([Serving](
-https://github.com/knative/serving/blob/main/support/COMMUNITY_CONTACTS.md)
-or [Eventing](
-https://github.com/knative/eventing/blob/main/support/COMMUNITY_CONTACTS.md))
+([Serving](https://github.com/knative/serving/blob/main/support/COMMUNITY_CONTACTS.md)
+or [Eventing](https://github.com/knative/eventing/blob/main/support/COMMUNITY_CONTACTS.md))
 to support users and keep test quality high, as well as release leads
 [rotation](https://github.com/knative/pkg/blob/main/RELEASE-LEADS.md) to
 shepherd Knative releases.
@@ -217,7 +216,6 @@ For existing working groups:
 - Recognized in the project as an active participant
 
 - Recognized as having expertise in the group’s subject matter
-
 
 ### Responsibilities and privileges
 
@@ -260,7 +258,6 @@ The following apply to the area / component for which one would be a lead.
 - Write access to repo (assign issues/PRs, add/remove labels and milestones,
   edit issues and PRs, edit wiki, create/delete labels and milestones)
 
-
   - Expected to respect OWNERS files approvals and use
     [standard procedure for merging code](./REVIEWING.md#merging-prs)
 
@@ -276,19 +273,29 @@ The following apply to the area / component for which one would be a lead.
 
   - Mentoring and guiding approvers, members, and new contributors.
 
+- Access to schedule events on the Knative shared calendar, and log in to the
+  Knative Zoom account
+
+- Recognition as a [CNCF project
+  maintainer](https://github.com/cncf/foundation/blob/main/project-maintainers.csv),
+  including access to the [CNCF Service
+  Desk](https://cncfservicedesk.atlassian.net/servicedesk/customer/portal/1/user/login?destination=portal%2F1)
+
 ## Stepping Down/Emeritus Process
+
 If and when contributors' commitment levels change, contributors can consider stepping down (moving down the contributor ladder) or moving to emeritus status (completely stepping away from the project).
 
 Once a member has decided to move to emeritus or step down the contributor ladder, their entries in Peribolos should be removed or modified according to the specific change. Members moving to emiritus status should be removed from the Knative GitHub organization in Peribolos through a PR submitted by the member or a member of the Steering Committee.
 
 ## Inactivity
+
 It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
-* Inactivity is measured by:
-    * Periods of no contributions for longer than 12 months
-    * Periods of no communication for longer than 12 months
-* Consequences of being inactive include:
-    * Involuntary Removal or demotion
+- Inactivity is measured by:
+  - Periods of no contributions for longer than 12 months
+  - Periods of no communication for longer than 12 months
+- Consequences of being inactive include:
+  - Involuntary Removal or demotion
 
 ## Involuntary Removal or Demotion
 
@@ -316,7 +323,7 @@ Approver.
   not fulfilling their documented responsibilities for more than 1 month.
   - This MAY be done through a super-majority vote of managers, or if there are
     not enough active managers to get a super-majority of votes cast, then
-    removal MAY occur through exception process to the Steering Committee.  The PR removing the
+    removal MAY occur through exception process to the Steering Committee. The PR removing the
     manager should be open for at least 72 hours.
   - Prior to voting to remove a manager, leads SHOULD reach out to the affected
     manager and see if they need to take a leave.

--- a/STEERING-COMMITTEE.md
+++ b/STEERING-COMMITTEE.md
@@ -73,7 +73,7 @@ committee currently recognizes this delegated authority for:
 
 ## Committee Meetings
 
-KSC currently meets weekly, or as-needed. Meetings are open to public and held
+KSC currently meets biweekly, or as-needed. Meetings are open to public and held
 online.
 
 Given the private nature of some of these discussions (e.g. privacy, private
@@ -94,10 +94,7 @@ for other options.
 ## Committee members
 
 Seats on the Steering Committee are held by an individual, not by their
-employer.  The current composition of the Steering Committee consists of members
-elected to the Steering Committee in 2022 and 2023, and the members of the
-Technical Oversight Committee elected in 2022; this is a temporary measure until
-elections are held in 2024.
+employer.
 
 The current membership of the committee is currently (listed alphabetically by
 first name):
@@ -118,7 +115,7 @@ The steering committee desires to always reach consensus.
 Decisions requiring a vote include: issuing written policy, amending existing
 written policy, creating, removing, or modifying a working group, all spending,
 hiring, and contracting, official responses to publicly raised issues, or any
-other decisions that at least half the members present decide require a vote
+other decisions that at least half the members present decide require a vote.
 
 Decisions are made in meetings when a quorum of the members are present and may
 pass with at least half the members of the committee supporting it.
@@ -147,8 +144,8 @@ composed as follows:
 
 - Four (4) are elected Contributing Seats, open to any project contributor.
   Two (2) Contributing Seats are elected every year, and serve a two-year term.
-  In the event of a vacancy, the Steering Committee may select a replacement to
-  serve out the remainder of the term.
+  In the event of a vacancy, [the procedures specified in that section](#vacancies)
+  are used to select a candidate to fill the remainder of the term.
 
 - One (1) is an [End User Seat](#end-user-seat) appointed by the Steering
   Committee.  The End User Seat serves until the next elected Steering Committee
@@ -163,6 +160,22 @@ composed as follows:
 Steering Committee contributing members serve for 2-year terms, staggered in
 order to preserve continuity. End user and selected members serve for 1-year
 terms. Every year two contributor seats are elected.
+
+## Removal Of Members
+
+Steering Committee members are expected to remain active in the community
+throughout their term.  If a Steering Committee member is inactive (no PR or
+issue comments, no Slack communications, and no meeting attendance) for more
+than 3 months, they may be removed by a simple majority vote of the remaining
+active committee members.  Steering Commmittee members may also be removed by
+a majority vote of all committee members using the same process as [amendments
+to this charter](#changes-to-the-charter).
+
+Steering Committee members may choose to resign and be removed at any time by
+notifying the project via an issue in this repository.
+
+Replacement of a Steering Committee member is handled in the same way as other
+Steering Committee [vacancies](#vacancies).
 
 ### Limitations on Company Representation
 


### PR DESCRIPTION
# Changes

- Documents the expectation that steering committee members remain active.
- Documents the process for removing a steering committee member, either due to inactivity, or for cause.
- Clears up an ambiguous section which defined a _second_ way of filling a KSC vacancy.  (Oops!)

/kind governance
Fixes #1687


Note that this is purely to address feedback from the governance review, and mostly just clarifies rules that we'd make up on the spot (using the charter approval process) if we needed them.