### PR TITLE
fix: eventing writers have write permissions for ekb

### DIFF
--- a/peribolos/knative-extensions.yaml
+++ b/peribolos/knative-extensions.yaml
@@ -634,6 +634,7 @@ orgs:
           eventing-gitlab: write
           eventing-integrations: write
           eventing-istio: write
+          eventing-kafka-broker: write
           eventing-kogito: write
           eventing-natss: write
           eventing-prometheus: write


### PR DESCRIPTION
# Changes

- Give the Eventing Writers group write permissions for the EKB repo