### PR TITLE
Add 'docs' label for clotributor searches

### DIFF
--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -100,6 +100,11 @@ default:
       target: both
       prowPlugin: label
       addedBy: humans
+    - color: 46428c
+      name: docs
+      target: both
+      prowPlugin: label
+      addedBy: humans
 
     # Specific labels for issue triage
     # See https://apenwarr.ca/log/20171213#slide32 for why we want to have these labels


### PR DESCRIPTION
# Changes

- :gift: add `docs` label to enable https://clotributor.dev/search?foundation=cncf&project=knative&area=docs

/kind cleanup
