### PR TITLE
Add Bruce Hamilton, CNCF tech docs writer

### DIFF
--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -44,6 +44,7 @@ orgs:
     - geekygirldawn
     - houshengbo
     - ikavgo
+    - iRaindrop
     - jberkus
     - jrangelramos
     - kahirokunn


### PR DESCRIPTION
# Changes

- Adds Bruce Hamilton, who is helping with the CNCF techdocs improvements to the Knative documentation.
