### PR TITLE
Extend SC nomination deadline

### DIFF
--- a/elections/2025-SC/README.md
+++ b/elections/2025-SC/README.md
@@ -34,10 +34,10 @@ to check if you are eligible by logging into [Elekto]. See Voting Process below 
 | Date         | Event                    |
 | ------------ | ------------------------ |
 | November 6   | Announcement of Election, call for nominations, exceptions |
-| November 24  | All candidate nominations due by 23:59 UTC (4:59pm Pacific) |
-| November 26  | Election Begins via Elekto UI |
-| December 5   | Voter exception requests due by 23:59 UTC (4:59pm Pacific) |
-| December 12  | Election Closes by 23:59 UTC (4:59pm Pacific) |
+| December 3   | All candidate nominations due by 23:59 UTC (4:59pm Pacific) |
+| December 5   | Election Begins via Elekto UI |
+| December 9   | Voter exception requests due by 23:59 UTC (4:59pm Pacific) |
+| December 15  | Election Closes by 23:59 UTC (4:59pm Pacific) |
 | December 19  | Announcement of Results |
 
 ## Election Officers

--- a/elections/2025-SC/election.yaml
+++ b/elections/2025-SC/election.yaml
@@ -1,7 +1,7 @@
 name: Knative 2025 SC
 organization: Knative
-start_datetime: 2025-11-26 00:00:01
-end_datetime: 2025-12-12 23:59:59
+start_datetime: 2025-12-05 00:00:01
+end_datetime: 2025-12-15 23:59:59
 no_winners: 2
 allow_no_opinion: True
 delete_after: True
@@ -13,4 +13,4 @@ election_officers:
   - Cali0707
 eligibility: All Knative contributors with more than 25 contributions in the last 12 months are eligible to vote
 exception_description: If you should be eligible to vote, and find that you are unable to, please fill out the exceptions form.    Otherwise, contact elections@knative.team
-exception_due: 2025-12-05 23:59:59
+exception_due: 2025-12-09 23:59:59

--- a/elections/2025-SC/election_desc.md
+++ b/elections/2025-SC/election_desc.md
@@ -11,10 +11,10 @@ All Knative contributors with [25 or more contributions](https://knative.devstat
 ### Schedule
 
 * November 5: Announcement of Election, call for nominations, exceptions
-* November 24: All candidate nominations due by 23:59 UTC (4:59pm Pacific)
-* November 26: Election Begins via Elekto UI
-* December 5: Voter exception requests due by 23:59 UTC (4:59pm Pacific)
-* December 12: Election Closes by 23:59 UTC (4:59pm Pacific)
+* December 3: All candidate nominations due by 23:59 UTC (4:59pm Pacific)
+* December 5: Election Begins via Elekto UI
+* December 9: Voter exception requests due by 23:59 UTC (4:59pm Pacific)
+* December 15: Election Closes by 23:59 UTC (4:59pm Pacific)
 * December 19: Announcement of Results
 
 ## Changing Your Vote


### PR DESCRIPTION
We currently do not have enough nominations to run the 2025 SC election. This PR moves the deadline to later so we can get more nominations