### PR TITLE
Add kahirokunn to operations-reviewers

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -62,6 +62,7 @@ aliases:
   operations-reviewers:
   - aliok
   - houshengbo
+  - kahirokunn
   - matzew
   operations-wg-leads:
   - houshengbo

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -454,6 +454,7 @@ orgs:
         members:
         - aliok
         - houshengbo
+        - kahirokunn
         - matzew
       Operations Writers:
         description: Grants write access to operations-related repositories.


### PR DESCRIPTION
I've been contributing to the Knative ecosystem, mainly around Knative Operator. Through this, I would like to help out more.

If the maintainers are open to it, I'd appreciate the opportunity to contribute as a reviewer for the Operations Working Group.

Thank you for considering.
