### PR TITLE
Add kahirokunn to operations-writers

### DIFF
--- a/peribolos/knative-OWNERS_ALIASES
+++ b/peribolos/knative-OWNERS_ALIASES
@@ -69,6 +69,7 @@ aliases:
   operations-writers:
   - aliok
   - houshengbo
+  - kahirokunn
   - matzew
   productivity-leads:
   - cardil

--- a/peribolos/knative.yaml
+++ b/peribolos/knative.yaml
@@ -464,6 +464,7 @@ orgs:
           operator: write
         members:
         - aliok
+        - kahirokunn
         - matzew
         teams:
           Operations WG Leads:


### PR DESCRIPTION
I've been contributing to the Knative ecosystem, mainly around Knative Operator. Through this, I would like to help out more.

If the maintainers are open to it, I'd appreciate the opportunity to contribute as a writer for the Operations Working Group.

Thank you for considering.
